### PR TITLE
Alpha 0.0.2.0

### DIFF
--- a/ModConfigManagerClient/Initializer.cs
+++ b/ModConfigManagerClient/Initializer.cs
@@ -1,4 +1,5 @@
-﻿using ModdingToolkit.Patches;
+﻿using Microsoft.Xna.Framework.Input;
+using ModdingToolkit.Patches;
 
 [assembly: IgnoresAccessChecksTo("Barotrauma")]
 [assembly: IgnoresAccessChecksTo("NetScriptAssembly")]

--- a/ModConfigManagerClient/MSettingsMenu.cs
+++ b/ModConfigManagerClient/MSettingsMenu.cs
@@ -1,24 +1,32 @@
-﻿using System.Globalization;
+﻿using System.Diagnostics;
+using System.Globalization;
 using System.Text.RegularExpressions;
 using Barotrauma.Networking;
 using Barotrauma.Steam;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
+using ModdingToolkit.Client;
 using ModdingToolkit.Config;
+using MonoMod.Utils;
 
 namespace ModConfigManager;
 
 public class MSettingsMenu : Barotrauma.SettingsMenu, ISettingsMenu
 {
-    private static readonly Dictionary<IConfigBase.Category, List<IConfigBase>?> PerMenuConfig = new();
-    private static readonly List<IConfigControl?> ControlsMenuConfig = new();
-    private static readonly List<(object, IConfigBase)> ValuesToSave = new();
-    private List<IConfigBase> OrganizedList = new();
-
+    private static readonly Dictionary<Category, List<IDisplayable>> PerMenuConfig = new();
+    private static readonly List<DisplayableControl> ControlsMenuConfig = new();
+    private static readonly List<(object, IDisplayable)> ValuesToSave = new();
+    //private List<IDisplayable> OrganizedList = new();
     public readonly Dictionary<GUIButton, Func<LocalizedString>> CustomInputValueNameGetters = new();
+    // Gameplay Tab
+    private GUILayoutGroup? Gameplay_MasterLayout;
+    private string? Gameplay_SelectedMod;
+    private string? Gameplay_SelectedCategory;
+    private string? Gameplay_KeywordFilter;
+    public static readonly string GAMEPLAY_SEARCHBAR_DELIMITER = ";";
 
     private record ResetHandle(string id, System.Action handle);
-    private readonly Dictionary<IConfigBase.Category, List<ResetHandle>> PerMenuResetHandles = new();
+    private readonly Dictionary<Category, List<ResetHandle>> PerMenuResetHandles = new();
 
     public MSettingsMenu(RectTransform mainParent, GameSettings.Config setConfig = default) : base(mainParent, setConfig)
     {
@@ -27,23 +35,21 @@ public class MSettingsMenu : Barotrauma.SettingsMenu, ISettingsMenu
 
     private static void Init()
     {
-        foreach (IConfigBase.Category category in Enum.GetValues<IConfigBase.Category>())
+        foreach (Category category in Enum.GetValues<Category>())
         {
-            if (!PerMenuConfig.ContainsKey(category))
-                PerMenuConfig.Add(category, new List<IConfigBase>());
-            if (PerMenuConfig[category] is null)
-                PerMenuConfig[category] = new List<IConfigBase>();
+            if (category is Category.Ignore or Category.Controls)   // Controls are handled separately.
+                continue;
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+            if (!PerMenuConfig.ContainsKey(category) || PerMenuConfig[category] is null)
+                PerMenuConfig[category] = new List<IDisplayable>();
             else
-                PerMenuConfig[category]!.Clear();
-            foreach (IConfigBase member in ConfigManager.GetConfigMembers(category))
-                PerMenuConfig[category]!.Add(member);
+                PerMenuConfig[category].Clear();
+            foreach (IDisplayable member in ConfigManager.GetDisplayableConfigs().Where(d => d.MenuCategory == category))
+                PerMenuConfig[category].Add(member);
         }
         
         ControlsMenuConfig.Clear();
-        foreach (IConfigControl member in ConfigManager.GetControlConfigs())
-        {
-            ControlsMenuConfig.Add(member);
-        }
+        ControlsMenuConfig.AddRange(ConfigManager.GetControlConfigs());
     }
     
     public new static Barotrauma.SettingsMenu Create(RectTransform mainParent)
@@ -295,7 +301,7 @@ public class MSettingsMenu : Barotrauma.SettingsMenu, ISettingsMenu
                 
                 addInputToRowCustom(
                     currentRow,
-                    $"{input.ModName}: {input.Name}",
+                    $"{input.Displayable.ModName}: {input.Displayable.Name}",
                     () =>
                     {
                         foreach ((object, IConfigBase) tuple in ValuesToSave)
@@ -309,18 +315,18 @@ public class MSettingsMenu : Barotrauma.SettingsMenu, ISettingsMenu
                                     : new RawLString(km.MouseButton.ToString());
                             }
                         }
-                        return new RawLString(FormatControlString(input.GetStringValue()));
+                        return new RawLString(FormatControlString(input.Displayable.GetStringValue()));
                     },
                     kom =>
                     {
                         if (kom.MouseButton == MouseButton.None)
                         {
-                            if (input.ValidateString(kom.Key.ToString()))
-                                AddOrUpdateUnsavedChange(kom, input);
+                            if (input.Displayable.ValidateString(kom.Key.ToString()))
+                                AddOrUpdateUnsavedChange(kom, input.Displayable);
                         }
-                        else if (input.ValidateString(kom.MouseButton.ToString()))
+                        else if (input.Displayable.ValidateString(kom.MouseButton.ToString()))
                         {
-                            AddOrUpdateUnsavedChange(kom, input);
+                            AddOrUpdateUnsavedChange(kom, input.Displayable);
                         }
 
                     });
@@ -343,11 +349,9 @@ public class MSettingsMenu : Barotrauma.SettingsMenu, ISettingsMenu
                     unsavedConfig.InventoryKeyMap = GameSettings.Config.InventoryKeyMapping.GetDefault();
                     unsavedConfig.KeyMap = GameSettings.Config.KeyMapping.GetDefault();
                     ValuesToSave.Clear();
-                    foreach (IConfigControl? control in ControlsMenuConfig)
+                    foreach (DisplayableControl displayableControl in ControlsMenuConfig)
                     {
-                        if (control is null)
-                            continue;
-                        AddOrUpdateUnsavedChange(control.DefaultValue, control);
+                        AddOrUpdateUnsavedChange(displayableControl.Control.DefaultValue, displayableControl.Displayable);
                     }
                     
                     foreach (var btn in inputButtonValueNameGetters.Keys)
@@ -365,15 +369,15 @@ public class MSettingsMenu : Barotrauma.SettingsMenu, ISettingsMenu
             };
     }
 
-    public void AddOrUpdateUnsavedChange(object newVal, IConfigBase config)
+    public void AddOrUpdateUnsavedChange(object newVal, IDisplayable config)
     {
         ValuesToSave.RemoveAll(tuple => tuple.Item2.Equals(config));
         ValuesToSave.Add((newVal, config));
     }
 
-    public object? GetUnsavedValue(IConfigBase config)
+    public object? GetUnsavedValue(IDisplayable config)
     {
-        foreach ((object, IConfigBase) tuple in ValuesToSave)
+        foreach ((object, IDisplayable) tuple in ValuesToSave)
         {
             if (tuple.Item2.Equals(config))
             {
@@ -387,9 +391,19 @@ public class MSettingsMenu : Barotrauma.SettingsMenu, ISettingsMenu
     public new void CreateGameplayTab()
     {
         GUIFrame content = CreateNewContentFrame(Tab.Gameplay);
-        var (left, right) = CreateSidebars(content);
         
-        #region LEFT_FRAME
+        // Layout
+        Gameplay_MasterLayout = new GUILayoutGroup(new RectTransform((1f, 1f), content.RectTransform));
+
+        Gameplay_KeywordFilter = "";
+        Gameplay_SelectedMod = "";
+        Gameplay_SelectedCategory = "";
+        Gameplay_GenerateGameplayScreen();
+
+        // Old Menu Code
+        //var (left, right) = CreateSidebars(content);
+
+        /*#region LEFT_FRAME
         var languages = TextManager.AvailableLanguages
             .OrderBy(l => TextManager.GetTranslatedLanguageName(l).ToIdentifier())
             .ToArray();
@@ -475,18 +489,18 @@ public class MSettingsMenu : Barotrauma.SettingsMenu, ISettingsMenu
             });
 #endif
 
-        #endregion
+        #endregion*/
 
-        #region RIGHT_FRAME
+        /*#region RIGHT_FRAME
 
-        if (!PerMenuResetHandles.ContainsKey(IConfigBase.Category.Gameplay))
-            PerMenuResetHandles.Add(IConfigBase.Category.Gameplay, new List<ResetHandle>());
+        if (!PerMenuResetHandles.ContainsKey(Category.Gameplay))
+            PerMenuResetHandles.Add(Category.Gameplay, new List<ResetHandle>());
         else
-            PerMenuResetHandles[IConfigBase.Category.Gameplay].Clear();
+            PerMenuResetHandles[Category.Gameplay].Clear();
         
-        if (PerMenuConfig[IConfigBase.Category.Gameplay] is null)
+        if (PerMenuConfig[Category.Gameplay] is null)
             return;
-        List<IConfigBase> cfgList = PerMenuConfig[IConfigBase.Category.Gameplay]!;
+        List<IDisplayable> cfgList = PerMenuConfig[Category.Gameplay]!;
         
         int groupCount = cfgList.GroupBy(x => x.ModName).Count();
         int entryCount = cfgList.Count;
@@ -517,9 +531,9 @@ public class MSettingsMenu : Barotrauma.SettingsMenu, ISettingsMenu
         {
             OnClicked = (button, o) =>
             {
-                if (PerMenuResetHandles.ContainsKey(IConfigBase.Category.Gameplay))
+                if (PerMenuResetHandles.ContainsKey(Category.Gameplay))
                 {
-                    foreach (var resetHandle in PerMenuResetHandles[IConfigBase.Category.Gameplay])
+                    foreach (var resetHandle in PerMenuResetHandles[Category.Gameplay])
                     {
                         resetHandle.handle?.Invoke();
                     }
@@ -542,184 +556,390 @@ public class MSettingsMenu : Barotrauma.SettingsMenu, ISettingsMenu
 
         string _header = string.Empty;
 
-        foreach (IConfigBase configBase in OrganizedList)
+        foreach (IDisplayable displayable in OrganizedList)
         {
-            if (!_header.Equals(configBase.ModName))
+            if (!_header.Equals(displayable.ModName))
             {
-                _header = configBase.ModName;
+                _header = displayable.ModName;
                 ModdingToolkit.Client.GUIUtil.Spacer(contentGroup, 1f/size);
                 ModdingToolkit.Client.GUIUtil.Label(contentGroup, $"{_header} Settings", GUIStyle.LargeFont, 1f/size);
                 ModdingToolkit.Client.GUIUtil.Spacer(contentGroup, 1f/size);
             }
 
-            PerMenuResetHandles[IConfigBase.Category.Gameplay].Add(new ResetHandle(
-                configBase.ModName+configBase.Name,
-                AddListEntry(contentGroup, configBase, (1.0f, entrySize.Y/size), 1f/size))
+            PerMenuResetHandles[Category.Gameplay].Add(new ResetHandle(
+                displayable.ModName+displayable.Name,
+                AddListEntry(contentGroup, displayable, (1.0f, entrySize.Y/size), 1f/size))
             );
         }
+
+        #endregion*/
+    }
+    
+    
+
+    private bool KeywordFilterContainsAny(IDisplayable? displayable, string? keywords, bool trueIfKeywordsNull = true)
+    {
+        if (displayable is null)
+            return false;
+        if (keywords.IsNullOrWhiteSpace())
+            return trueIfKeywordsNull;
+
+        string[] keywordsS = keywords.Split(GAMEPLAY_SEARCHBAR_DELIMITER);
         
-        System.Action AddListEntry(GUILayoutGroup layoutGroup, IConfigBase entry, Vector2 scaleRatio, float yAdjustRatio = 1.0f)
+        Stack<string> keywordStack = new Stack<string>();
+
+        foreach (string s in keywordsS)
         {
-            ModdingToolkit.Client.GUIUtil.Label(layoutGroup, entry.Name, GUIStyle.SubHeadingFont, yAdjustRatio);
-            if (entry.GetDisplayType() == IConfigBase.DisplayType.Tickbox)
+            if (!s.IsNullOrWhiteSpace())
+                keywordStack.Push(s.ToLowerInvariant().Trim());
+        }
+
+        if (keywordStack.Count < 1)
+            return trueIfKeywordsNull;
+        
+        return RecursiveCheck();
+        
+        bool RecursiveCheck()
+        {
+            string s = keywordStack.Pop();
+            return
+                (!displayable.Name.IsNullOrWhiteSpace() && displayable.Name.ToLowerInvariant().Contains(s))
+                || (!displayable.DisplayName.IsNullOrWhiteSpace() && displayable.DisplayName.ToLowerInvariant().Contains(s))
+                || (!displayable.ModName.IsNullOrWhiteSpace() && displayable.ModName.ToLowerInvariant().Contains(s))
+                || (!displayable.DisplayModName.IsNullOrWhiteSpace() && displayable.DisplayModName.ToLowerInvariant().Contains(s))
+                || (keywordStack.Count > 0 && RecursiveCheck());
+        }
+    }
+
+    private void Gameplay_GenerateGameplayScreen()
+    {
+        if (Gameplay_MasterLayout is null)
+            return;
+
+        #region DATA_DEF
+
+        // Defs
+        string includeAllOption = "All";
+        
+        // Mod List
+        var modDisplayablesList = new List<IDisplayable>();
+        
+        if (PerMenuConfig.ContainsKey(Category.Gameplay)
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+            && PerMenuConfig[Category.Gameplay] is not null
+            && PerMenuConfig[Category.Gameplay].Any())
+        {
+            modDisplayablesList.AddRange(PerMenuConfig[Category.Gameplay]
+                .Where(d => KeywordFilterContainsAny(d, Gameplay_KeywordFilter))
+                .ToList());
+        }
+
+        // Build Mod List for Dropdown
+        List<string> modListDropdown = new List<string>();
+        modListDropdown.Add(includeAllOption);
+        modListDropdown.Add("Vanilla");
+        modListDropdown.AddRange(modDisplayablesList
+            .GroupBy(d => d.DisplayModName)
+            .Select(d => d.Key));
+        modListDropdown = modListDropdown.Distinct().ToList();
+
+        //--- Set current mod selection
+        if (Gameplay_SelectedMod.IsNullOrWhiteSpace() || !modListDropdown.Contains(Gameplay_SelectedMod))
+            Gameplay_SelectedMod = includeAllOption;
+        
+        // Build Category List for Dropdown
+        List<string> categoryList = new List<string>();
+        categoryList.Add("All");
+        categoryList.AddRange(modDisplayablesList
+            .Where(d => Gameplay_SelectedMod.Equals("All") || d.DisplayModName.Equals(Gameplay_SelectedMod))
+            .GroupBy(d => d.DisplayCategory)
+            .Select(dg => dg.Key));
+        categoryList = categoryList.Distinct().ToList();
+
+        //--- Set current category selection
+        if (Gameplay_SelectedCategory.IsNullOrWhiteSpace() || !categoryList.Contains(Gameplay_SelectedCategory))
+            Gameplay_SelectedCategory = includeAllOption;
+        
+        // Filter list of displayables
+        modDisplayablesList = modDisplayablesList
+            .Where(d => 
+                (d.DisplayModName.Equals(Gameplay_SelectedMod) || Gameplay_SelectedMod.Equals(includeAllOption)) 
+                && (d.DisplayCategory.Equals(Gameplay_SelectedCategory) || Gameplay_SelectedCategory.Equals(includeAllOption))
+            )
+            .OrderBy(d => d.DisplayModName)
+            .ThenBy(d => d.DisplayName)
+            .ToList();
+
+        #endregion
+
+        #region GUI_MENU_HEADER
+
+        // Begin building GUI Elements
+        // Clear existing view
+        GUIUtil.ClearChildElements(Gameplay_MasterLayout);
+        
+        // Header
+        var topHeader = GUIUtil.Label(Gameplay_MasterLayout, "Gameplay Settings", GUIStyle.LargeFont, Vector2.One);
+        GUIUtil.Spacer(Gameplay_MasterLayout, Vector2.One);
+        
+        // GUI Container Init
+        var modListDropdownGroup = new GUILayoutGroup(
+            new RectTransform((1f, 0.06f), Gameplay_MasterLayout.RectTransform), true, Anchor.CenterLeft);
+        var categoryListDropdownGroup = new GUILayoutGroup(
+            new RectTransform((1f, 0.06f), Gameplay_MasterLayout.RectTransform), true, Anchor.CenterLeft);
+        var searchBarGroup = new GUILayoutGroup(
+            new RectTransform((1f, 0.06f), Gameplay_MasterLayout.RectTransform), true, Anchor.CenterLeft);
+        
+        var modListLabelElement = GUIUtil.Label(modListDropdownGroup, new RawLString("Mod: "), GUIStyle.SubHeadingFont, (0.2f, 1f));
+        var modListDropdownElement = GUIUtil.Dropdown(
+            modListDropdownGroup,
+            s => new RawLString(s),
+            s => new RawLString(s),
+            modListDropdown,
+            Gameplay_SelectedMod,
+            s =>
             {
-                var tickbox = ModdingToolkit.Client.GUIUtil.Tickbox(layoutGroup, "", "",
-                    (bool)Convert.ChangeType(entry.GetStringValue(), TypeCode.Boolean),
-                    (v) => AddOrUpdateUnsavedChange(v.ToString(), entry), yAdjustRatio);
+                Gameplay_SelectedMod = s;
+                Gameplay_GenerateGameplayScreen();
+            },
+            (0.79f, 1f));
+
+        GUIUtil.Label(categoryListDropdownGroup, new RawLString("Category: "), GUIStyle.SubHeadingFont, (0.2f, 1f));
+        GUIUtil.Dropdown(
+            categoryListDropdownGroup,
+            s => new RawLString(s),
+            s => new RawLString(s),
+            categoryList,
+            Gameplay_SelectedCategory,
+            s =>
+            {
+                Gameplay_SelectedCategory = s;
+                Gameplay_GenerateGameplayScreen();
+            },
+            (0.79f, 1f));
+
+        GUIUtil.Label(searchBarGroup, new RawLString("Search: "), GUIStyle.SubHeadingFont, (0.2f, 1f));
+        new GUITextBox(
+            new RectTransform((0.79f, 1f), searchBarGroup.RectTransform),
+            Gameplay_KeywordFilter)
+        {
+            OnEnterPressed = (box, text) =>
+            {
+                Gameplay_KeywordFilter = text;
+                Gameplay_GenerateGameplayScreen();
+                return true;
+            }
+        };
+
+        #endregion
+
+        #region GUI_SETTINGS_ENTRIES
+
+        Vector2 entrySize = (1.0f, 0.122f);
+        float groupGount = modDisplayablesList.GroupBy(d => d.DisplayModName).Count();
+        float size = Math.Max(1.0f, 0.2f * groupGount + modDisplayablesList.Count * entrySize.Y);
+
+        // Settings List
+        var modDisplayListGroup = new GUILayoutGroup(
+            new RectTransform((1f, 0.7f), Gameplay_MasterLayout.RectTransform));
+        var modDisplayListBox = new GUIListBox(
+            new RectTransform((1f, 1f), modDisplayListGroup.RectTransform),
+            false,
+            Color.Black)
+        {
+            CanBeFocused = false,
+            OnSelected = (_, _) => false
+        };
+
+        
+        
+        // Reset button
+        GUIButton resetAllVars = new GUIButton(new RectTransform((0.2f, 0.1f), Gameplay_MasterLayout.RectTransform),
+            "Reset", color: Color.Beige)
+        {
+            OnClicked = (button, o) =>
+            {
+                if (PerMenuResetHandles.ContainsKey(Category.Gameplay))
+                {
+                    foreach (var resetHandle in PerMenuResetHandles[Category.Gameplay])
+                    {
+                        resetHandle.handle?.Invoke();
+                    }
+                }
+                return false;
+            },
+            OnAddedToGUIUpdateList = component =>
+            {
+                component.Enabled = CurrentTab == Tab.Gameplay;
+            }
+        };
+        
+        // Populate displayable GUIListBox
+        
+        GUIFrame displayableContentFrame = new GUIFrame(
+            new RectTransform((1.0f, size), modDisplayListBox.Content.RectTransform),
+            "", Color.DarkOliveGreen);
+
+        GUILayoutGroup displayableContentGroup = new GUILayoutGroup(
+            new RectTransform((1.0f, 1.0f), displayableContentFrame.RectTransform),
+            false);
+
+        string _header = string.Empty;
+
+        if (!PerMenuResetHandles.ContainsKey(Category.Gameplay))
+            PerMenuResetHandles.Add(Category.Gameplay, new List<ResetHandle>());
+        
+        foreach (IDisplayable displayable in modDisplayablesList)
+        {
+            if (!_header.Equals(displayable.DisplayModName))
+            {
+                _header = displayable.DisplayModName;
+                GUIUtil.Spacer(displayableContentGroup, new Vector2(1f, 1f/size));
+                GUIUtil.Label(displayableContentGroup, $"{_header}", GUIStyle.LargeFont, new Vector2(1f, 1f/size));
+                GUIUtil.Spacer(displayableContentGroup, new Vector2(1f, 1f/size));
+            }
+
+            PerMenuResetHandles[Category.Gameplay].Add(new ResetHandle(
+                displayable.ModName+displayable.Name,
+                AddListEntry(displayableContentGroup, displayable, (1.0f, entrySize.Y/size), new Vector2(1f, 1f/size)))
+            );
+        }
+
+        #endregion
+    }
+
+    private System.Action AddListEntry(GUILayoutGroup layoutGroup, IDisplayable entry, Vector2 scaleRatio, Vector2 adjustRatio)
+    {
+        GUIUtil.Label(layoutGroup, entry.Name, GUIStyle.SubHeadingFont, adjustRatio);
+        if (entry.GetDisplayType() == DisplayType.Tickbox)
+        {
+            var tickbox = GUIUtil.Tickbox(layoutGroup, "", "",
+                (bool)Convert.ChangeType(entry.GetStringValue(), TypeCode.Boolean),
+                (v) => AddOrUpdateUnsavedChange(v.ToString(), entry), adjustRatio);
+            return () =>
+            {
+                bool b;
+                try
+                {
+                    b = (bool)Convert.ChangeType(entry.GetStringDefaultValue(), TypeCode.Boolean);
+                }
+                catch
+                {
+                    b = false;
+                }
+
+                tickbox.Selected = b;
+                AddOrUpdateUnsavedChange(b.ToString(), entry);
+            };
+        }
+        if (entry.GetDisplayType() == DisplayType.DropdownList
+                 && entry is IConfigList icl)
+        {
+            var dropdown = GUIUtil.Dropdown<string>(layoutGroup, 
+                s => new RawLString(s), 
+                s => new RawLString(s),
+                icl.GetReadOnlyList(), icl.Value, 
+                s => AddOrUpdateUnsavedChange(s, entry), adjustRatio);
+            return () =>
+            {
+                int index = icl.GetDefaultValueIndex();
+                if (index < 0)
+                    return;
+                dropdown.Select(index);
+                AddOrUpdateUnsavedChange(icl.GetStringDefaultValue(), entry);
+            };
+        }
+        if (entry.GetDisplayType() == DisplayType.Slider)
+        {
+            if (entry is IConfigRangeFloat icf)
+            {
+                float cv;
+                try
+                {
+                    cv = (float)Convert.ChangeType(GetUnsavedValue(entry), TypeCode.Single)!;
+                }
+                catch
+                {
+                    cv = icf.Value;
+                }
+
+                var (slider, label) = GUIUtil.Slider(layoutGroup,
+                    new Vector2(icf.MinValue, icf.MaxValue), icf.Steps, 
+                    f => f.ToString(), cv, 
+                    f => AddOrUpdateUnsavedChange(f.ToString(), entry),null, adjustRatio);
                 return () =>
                 {
-                    bool b;
-                    try
-                    {
-                        b = (bool)Convert.ChangeType(entry.GetStringDefaultValue(), TypeCode.Boolean);
-                    }
-                    catch
-                    {
-                        b = false;
-                    }
-
-                    tickbox.Selected = b;
-                    AddOrUpdateUnsavedChange(b.ToString(), entry);
+                    slider.BarScrollValue = icf.DefaultValue;
+                    label.Text = (RichString)slider.BarScrollValue.ToString();
+                    AddOrUpdateUnsavedChange(icf.DefaultValue.ToString(), entry);
                 };
             }
-            if (entry.GetDisplayType() == IConfigBase.DisplayType.DropdownList
-                     && entry is IConfigList icl)
+            if (entry is IConfigRangeInt ici)
             {
-                var dropdown = ModdingToolkit.Client.GUIUtil.Dropdown<string>(layoutGroup, 
-                    s => new RawLString(s), 
-                    s => new RawLString(s),
-                    icl.GetReadOnlyList(), icl.Value, 
-                    s => AddOrUpdateUnsavedChange(s, icl), yAdjustRatio);
-                return () =>
+                int cv;
+                try
                 {
-                    int index = icl.GetDefaultValueIndex();
-                    if (index < 0)
-                        return;
-                    dropdown.Select(index);
-                    AddOrUpdateUnsavedChange(icl.GetStringDefaultValue(), icl);
-                };
-            }
-            if (entry.GetDisplayType() == IConfigBase.DisplayType.Slider)
-            {
-                if (entry is IConfigRangeFloat icf)
-                {
-                    float cv;
-                    try
-                    {
-                        cv = (float)Convert.ChangeType(GetUnsavedValue(icf), TypeCode.Single)!;
-                    }
-                    catch
-                    {
-                        cv = icf.Value;
-                    }
-
-                    var (slider, label) = ModdingToolkit.Client.GUIUtil.Slider(layoutGroup,
-                        new Vector2(icf.MinValue, icf.MaxValue), icf.Steps, 
-                        f => f.ToString(), cv, 
-                        f => AddOrUpdateUnsavedChange(f.ToString(), entry), LayoutYAdjust: yAdjustRatio);
-                    return () =>
-                    {
-                        slider.BarScrollValue = icf.DefaultValue;
-                        label.Text = (RichString)slider.BarScrollValue.ToString();
-                        AddOrUpdateUnsavedChange(icf.DefaultValue.ToString(), icf);
-                    };
+                    cv = (int)Convert.ChangeType(GetUnsavedValue(entry), TypeCode.Int32)!;
                 }
-                if (entry is IConfigRangeInt ici)
+                catch
                 {
-                    int cv;
-                    try
-                    {
-                        cv = (int)Convert.ChangeType(GetUnsavedValue(ici), TypeCode.Int32)!;
-                    }
-                    catch
-                    {
-                        cv = ici.Value;
-                    }
-
-                    var (slider, label) = ModdingToolkit.Client.GUIUtil.Slider(layoutGroup,
-                        new Vector2(ici.MinValue, ici.MaxValue), ici.Steps, 
-                        f => f.ToString(), cv, 
-                        f => AddOrUpdateUnsavedChange(f.ToString(), entry), LayoutYAdjust: yAdjustRatio);
-                    
-                    return () =>
-                    {
-                        slider.BarScrollValue = ici.DefaultValue;
-                        label.Text = (RichString)slider.BarScrollValue.ToString();
-                        AddOrUpdateUnsavedChange(ici.DefaultValue.ToString(), ici);
-                    };
+                    cv = ici.Value;
                 }
 
-                return () => { };
-            }
-            //GUINumberInput breaks formatting, includes unknown padding
-            /*if (entry.GetDisplayType() == IConfigBase.DisplayType.Number)
-            {
-                var numInput = new ModConfigManager.CustomGUI.GUINumberInput(
-                    new RectTransform(scaleRatio, layoutGroup.RectTransform),
-                    NumberType.Float, yAdjustRatio: yAdjustRatio)
-                {
-                    OnValueChanged = input =>
-                    {
-                        AddOrUpdateUnsavedChange(input.FloatValue.ToString(), entry);
-                    }
-                };
+                var (slider, label) = GUIUtil.Slider(layoutGroup,
+                    new Vector2(ici.MinValue, ici.MaxValue), ici.Steps, 
+                    f => f.ToString(), cv, 
+                    f => AddOrUpdateUnsavedChange(f.ToString(), entry), null, adjustRatio);
                 
-                if (float.TryParse(entry.GetStringValue(), out var v))
-                {
-                    numInput.FloatValue = v;
-                }
-
                 return () =>
                 {
-                    if (float.TryParse(entry.GetStringDefaultValue(), out var fl))
-                    {
-                        numInput.FloatValue = fl;
-                        AddOrUpdateUnsavedChange(entry.GetStringDefaultValue(), entry);
-                    }
-                };
-            }*/
-            if (entry.GetDisplayType() == IConfigBase.DisplayType.Standard
-                     || entry.GetDisplayType() == IConfigBase.DisplayType.Number)
-            {
-                var textBox = new GUITextBox(
-                    new RectTransform(scaleRatio, layoutGroup.RectTransform),
-                    entry.GetStringValue(),
-                    createPenIcon: false
-                )
-                {
-                    OnEnterPressed = (box, text) =>
-                    {
-                        if (entry.ValidateString(text))
-                            AddOrUpdateUnsavedChange(text, entry);
-                        else
-                        {
-                            string s = String.Empty;
-                            try
-                            {
-                                s = (string)Convert.ChangeType(GetUnsavedValue(entry), TypeCode.String)!;
-                            }
-                            catch
-                            {
-                                s = entry.GetStringValue();
-                            }
-
-                            box.Text = s;
-                        }
-                        return true;
-                    }
-                };
-                return () =>
-                {
-                    string s = entry.GetStringDefaultValue();
-                    textBox.Text = s;
-                    AddOrUpdateUnsavedChange(s, entry);
+                    slider.BarScrollValue = ici.DefaultValue;
+                    label.Text = (RichString)slider.BarScrollValue.ToString();
+                    AddOrUpdateUnsavedChange(ici.DefaultValue.ToString(), entry);
                 };
             }
 
             return () => { };
         }
-        
-        #endregion
+        if (entry.GetDisplayType() == DisplayType.Standard
+            || entry.GetDisplayType() == DisplayType.Number)
+        {
+            var textBox = new GUITextBox(
+                new RectTransform(scaleRatio, layoutGroup.RectTransform),
+                entry.GetStringValue(),
+                createPenIcon: false
+            )
+            {
+                OnEnterPressed = (box, text) =>
+                {
+                    if (entry.ValidateString(text))
+                        AddOrUpdateUnsavedChange(text, entry);
+                    else
+                    {
+                        string s = String.Empty;
+                        try
+                        {
+                            s = (string)Convert.ChangeType(GetUnsavedValue(entry), TypeCode.String)!;
+                        }
+                        catch
+                        {
+                            s = entry.GetStringValue();
+                        }
+
+                        box.Text = s;
+                    }
+                    return true;
+                }
+            };
+            return () =>
+            {
+                string s = entry.GetStringDefaultValue();
+                textBox.Text = s;
+                AddOrUpdateUnsavedChange(s, entry);
+            };
+        }
+
+        return () => { };
     }
 
     public new void CreateGraphicsTab()

--- a/ModConfigManagerClient/MSettingsMenu.cs
+++ b/ModConfigManagerClient/MSettingsMenu.cs
@@ -307,7 +307,7 @@ public class MSettingsMenu : Barotrauma.SettingsMenu, ISettingsMenu
                         foreach ((object, IConfigBase) tuple in ValuesToSave)
                         {
                             if (tuple.Item2 is IConfigControl icc
-                                && icc == input
+                                && icc == input.Control
                                 && tuple.Item1 is KeyOrMouse km)
                             {
                                 return km.MouseButton == MouseButton.None

--- a/ModdingToolkit/CSharp/Client/Config/ConfigControl.cs
+++ b/ModdingToolkit/CSharp/Client/Config/ConfigControl.cs
@@ -55,8 +55,8 @@ public sealed class ConfigControl : IConfigControl, IDisplayable
 
     public DisplayType GetDisplayType() => DisplayType.KeyOrMouse;
 
-    public void InitializeDisplay(string name = "", string modName = "", string displayName = "", string displayModName = "",
-        string displayCategory = "", string tooltip = "", string imageIcon = "", Category menuCategory = Category.Gameplay)
+    public void InitializeDisplay(string? name = "", string? modName = "", string? displayName = "", string? displayModName = "",
+        string? displayCategory = "", string? tooltip = "", string? imageIcon = "", Category menuCategory = Category.Gameplay)
     {
         if (!displayName.IsNullOrWhiteSpace())
             this.DisplayName = displayName;

--- a/ModdingToolkit/CSharp/Client/Config/ConfigControl.cs
+++ b/ModdingToolkit/CSharp/Client/Config/ConfigControl.cs
@@ -8,9 +8,12 @@ public sealed class ConfigControl : IConfigControl
 {
     private event System.Func<KeyOrMouse, bool>? _validateInput;
     private event System.Action? _onValueChanged;
-    public string Name { get; set; } = String.Empty;
+    public string Name { get; private set; } = String.Empty;
+    public string DisplayName { get; private set; } = String.Empty;
+    public string ModName { get; private set; } = String.Empty;
+    public string DisplayModName { get; private set; } = String.Empty;
+    public string DisplayCategory { get; private set; } = String.Empty;
     public Type SubTypeDef => typeof(KeyOrMouse);
-    public string ModName { get; set; } = String.Empty;
     public IConfigBase.Category MenuCategory => IConfigBase.Category.Ignore;
     public NetworkSync NetSync => NetworkSync.NoSync;
 
@@ -66,7 +69,8 @@ public sealed class ConfigControl : IConfigControl
 
     public KeyOrMouse DefaultValue { get; private set; } = new KeyOrMouse(Keys.NumLock);
 
-    public void Initialize(string name, string modName, KeyOrMouse? currentValue, KeyOrMouse? defaultValue, System.Action? onValueChanged)
+    public void Initialize(string name, string modName, KeyOrMouse? currentValue, KeyOrMouse? defaultValue, System.Action? onValueChanged,
+        string? displayName = null, string? displayModName = null, string? displayCategory = null)
     {
         if (name.Trim().IsNullOrEmpty())
             throw new ArgumentNullException($"ConfigControl::Initialize() | Name is null or empty.");
@@ -76,6 +80,15 @@ public sealed class ConfigControl : IConfigControl
         this.Name = name;
         this.ModName = modName;
         this.Value = currentValue;
+        
+        // Client menu data
+        if (displayName is not null)
+            this.DisplayName = displayName;
+        if (displayModName is not null)
+            this.DisplayModName = displayModName;
+        if (displayCategory is not null)
+            this.DisplayCategory = displayCategory;
+        
         if (defaultValue is not null)
             this.DefaultValue = defaultValue;
     }

--- a/ModdingToolkit/CSharp/Client/Config/ConfigControl.cs
+++ b/ModdingToolkit/CSharp/Client/Config/ConfigControl.cs
@@ -87,6 +87,34 @@ public sealed class ConfigControl : IConfigControl
         return this._validateInput?.Invoke(newValue) ?? true;
     }
 
+    public bool IsHit()
+    {
+        if (this.Value is null)
+            return false;
+        switch (this.Value.MouseButton)
+        {   
+            case MouseButton.None:
+                return Barotrauma.PlayerInput.KeyHit(this.Value.Key);
+            case MouseButton.PrimaryMouse:
+            case MouseButton.LeftMouse:
+                return Barotrauma.PlayerInput.PrimaryMouseButtonClicked();
+            case MouseButton.SecondaryMouse:
+            case MouseButton.RightMouse:
+                return Barotrauma.PlayerInput.SecondaryMouseButtonClicked();
+            case MouseButton.MiddleMouse:
+                return Barotrauma.PlayerInput.MidButtonClicked();
+            case MouseButton.MouseButton4:
+                return Barotrauma.PlayerInput.Mouse4ButtonClicked();
+            case MouseButton.MouseButton5:
+                return Barotrauma.PlayerInput.Mouse5ButtonClicked();
+            case MouseButton.MouseWheelUp:
+                return Barotrauma.PlayerInput.MouseWheelUpClicked();
+            case MouseButton.MouseWheelDown:
+                return Barotrauma.PlayerInput.MouseWheelDownClicked();
+        }
+        return false;
+    }
+
     public bool ValidateString(string value)
     {
         if (Enum.IsDefined(typeof(Keys), value))

--- a/ModdingToolkit/CSharp/Client/Config/ConfigControl.cs
+++ b/ModdingToolkit/CSharp/Client/Config/ConfigControl.cs
@@ -4,14 +4,19 @@ using ModdingToolkit.Networking;
 
 namespace ModdingToolkit.Config;
 
-public sealed class ConfigControl : IConfigControl
+public sealed class ConfigControl : IConfigControl, IDisplayable
 {
     private event System.Func<KeyOrMouse, bool>? _validateInput;
     private event System.Action? _onValueChanged;
-    public string Name { get; set; } = String.Empty;
+    public string Name { get; private set; } = String.Empty;
     public Type SubTypeDef => typeof(KeyOrMouse);
-    public string ModName { get; set; } = String.Empty;
-    public IConfigBase.Category MenuCategory => IConfigBase.Category.Ignore;
+    public string ModName { get; private set; } = String.Empty;
+    public string DisplayName { get; private set; }
+    public string DisplayModName { get; private set; }
+    public string DisplayCategory { get; private set; }
+    public string Tooltip { get; private set; }
+    public string ImageIcon { get; private set; }
+    public Category MenuCategory => Category.Controls;
     public NetworkSync NetSync => NetworkSync.NoSync;
 
     public string GetStringValue()
@@ -48,7 +53,22 @@ public sealed class ConfigControl : IConfigControl
             this.Value = new KeyOrMouse(DefaultValue.MouseButton);
     }
 
-    public IConfigBase.DisplayType GetDisplayType() => IConfigBase.DisplayType.KeyOrMouse;
+    public DisplayType GetDisplayType() => DisplayType.KeyOrMouse;
+
+    public void InitializeDisplay(string name = "", string modName = "", string displayName = "", string displayModName = "",
+        string displayCategory = "", string tooltip = "", string imageIcon = "", Category menuCategory = Category.Gameplay)
+    {
+        if (!displayName.IsNullOrWhiteSpace())
+            this.DisplayName = displayName;
+        if (!displayModName.IsNullOrWhiteSpace())
+            this.DisplayModName = displayModName;
+        if (!displayCategory.IsNullOrWhiteSpace())
+            this.DisplayCategory = displayCategory;
+        if (!tooltip.IsNullOrWhiteSpace())
+            this.Tooltip = tooltip;
+        if (!imageIcon.IsNullOrWhiteSpace())
+            this.ImageIcon = imageIcon;
+    }
 
     private KeyOrMouse? _value;
     public KeyOrMouse? Value

--- a/ModdingToolkit/CSharp/Client/Config/ConfigEntry.cs
+++ b/ModdingToolkit/CSharp/Client/Config/ConfigEntry.cs
@@ -1,4 +1,5 @@
-﻿using ModdingToolkit.Networking;
+﻿using Barotrauma.Networking;
+using ModdingToolkit.Networking;
 
 namespace ModdingToolkit.Config;
 
@@ -9,6 +10,9 @@ public partial class ConfigEntry<T> : IConfigEntry<T>, INetConfigBase, IDisplaya
     {
         if (!IsNetworked)
             return true;
+        if (NetSync is NetworkSync.ServerAuthority && GameMain.Client.HasPermission(ClientPermissions.ManageSettings))
+            return true;
+        
         return this.NetSync switch
         {
             NetworkSync.NoSync => true,
@@ -20,7 +24,8 @@ public partial class ConfigEntry<T> : IConfigEntry<T>, INetConfigBase, IDisplaya
     
     public void TriggerNetEvent()
     {
-        if (this.NetSync is NetworkSync.TwoWaySync)
+        if (NetSync is NetworkSync.TwoWaySync
+            || (NetSync is NetworkSync.ServerAuthority && GameMain.Client.HasPermission(ClientPermissions.ManageSettings)))
         {
             this._onNetworkEvent?.Invoke(this);
         } 

--- a/ModdingToolkit/CSharp/Client/Config/ConfigEntry.cs
+++ b/ModdingToolkit/CSharp/Client/Config/ConfigEntry.cs
@@ -2,7 +2,7 @@
 
 namespace ModdingToolkit.Config;
 
-public partial class ConfigEntry<T> : IConfigEntry<T>, INetConfigBase where T : IConvertible
+public partial class ConfigEntry<T> : IConfigEntry<T>, INetConfigBase, IDisplayable where T : IConvertible
 {
     public bool IsNetworked => this.NetSync != NetworkSync.NoSync && GameMain.IsMultiplayer;
     public bool NetAuthorityValidate()
@@ -25,4 +25,38 @@ public partial class ConfigEntry<T> : IConfigEntry<T>, INetConfigBase where T : 
             this._onNetworkEvent?.Invoke(this);
         } 
     }
+
+    public string DisplayName { get; private set; }
+    public string DisplayModName { get; private set; }
+    public string DisplayCategory { get; private set; }
+    public string Tooltip { get; private set; }
+    public string ImageIcon { get; private set; }
+    public Category MenuCategory { get; private set; }
+
+    public void InitializeDisplay(string name = "", string modName = "", string displayName = "", string displayModName = "",
+        string displayCategory = "", string tooltip = "", string imageIcon = "", Category menuCategory = Category.Gameplay)
+    {
+        if (!displayName.IsNullOrWhiteSpace())
+            this.DisplayName = displayName;
+        if (!displayModName.IsNullOrWhiteSpace())
+            this.DisplayModName = displayModName;
+        if (!displayCategory.IsNullOrWhiteSpace())
+            this.DisplayCategory = displayCategory;
+        if (!tooltip.IsNullOrWhiteSpace())
+            this.Tooltip = tooltip;
+        if (!imageIcon.IsNullOrWhiteSpace())
+            this.ImageIcon = imageIcon;
+        this.MenuCategory = menuCategory;
+        if (this.MenuCategory is Category.Controls)
+            this.MenuCategory = Category.Gameplay;
+    }
+    
+    public virtual DisplayType GetDisplayType() =>
+        typeof(T) switch
+        {
+            { IsEnum: true } => DisplayType.DropdownEnum,
+            { Name: nameof(Boolean) } => DisplayType.Tickbox,
+            { IsPrimitive: true } => DisplayType.Number,
+            _ => DisplayType.Standard
+        };
 }

--- a/ModdingToolkit/CSharp/Client/Config/ConfigEntry.cs
+++ b/ModdingToolkit/CSharp/Client/Config/ConfigEntry.cs
@@ -33,8 +33,8 @@ public partial class ConfigEntry<T> : IConfigEntry<T>, INetConfigBase, IDisplaya
     public string ImageIcon { get; private set; }
     public Category MenuCategory { get; private set; }
 
-    public void InitializeDisplay(string name = "", string modName = "", string displayName = "", string displayModName = "",
-        string displayCategory = "", string tooltip = "", string imageIcon = "", Category menuCategory = Category.Gameplay)
+    public void InitializeDisplay(string? name = "", string? modName = "", string? displayName = "", string? displayModName = "",
+        string? displayCategory = "", string? tooltip = "", string? imageIcon = "", Category menuCategory = Category.Gameplay)
     {
         if (!displayName.IsNullOrWhiteSpace())
             this.DisplayName = displayName;

--- a/ModdingToolkit/CSharp/Client/Config/ConfigList.cs
+++ b/ModdingToolkit/CSharp/Client/Config/ConfigList.cs
@@ -2,7 +2,7 @@
 
 namespace ModdingToolkit.Config;
 
-public partial class ConfigList : IConfigList, INetConfigBase
+public partial class ConfigList : IConfigList, INetConfigBase, IDisplayable
 {
     public bool IsNetworked => this.NetSync != NetworkSync.NoSync && GameMain.IsMultiplayer;
     public bool NetAuthorityValidate()
@@ -25,4 +25,31 @@ public partial class ConfigList : IConfigList, INetConfigBase
             this._onNetworkEvent?.Invoke(this);
         } 
     }
+    
+    public string DisplayName { get; private set; }
+    public string DisplayModName { get; private set; }
+    public string DisplayCategory { get; private set; }
+    public string Tooltip { get; private set; }
+    public string ImageIcon { get; private set; }
+    public Category MenuCategory { get; private set; }
+
+    public void InitializeDisplay(string name = "", string modName = "", string displayName = "", string displayModName = "",
+        string displayCategory = "", string tooltip = "", string imageIcon = "", Category menuCategory = Category.Gameplay)
+    {
+        if (!displayName.IsNullOrWhiteSpace())
+            this.DisplayName = displayName;
+        if (!displayModName.IsNullOrWhiteSpace())
+            this.DisplayModName = displayModName;
+        if (!displayCategory.IsNullOrWhiteSpace())
+            this.DisplayCategory = displayCategory;
+        if (!tooltip.IsNullOrWhiteSpace())
+            this.Tooltip = tooltip;
+        if (!imageIcon.IsNullOrWhiteSpace())
+            this.ImageIcon = imageIcon;
+        this.MenuCategory = menuCategory;
+        if (this.MenuCategory is Category.Controls)
+            this.MenuCategory = Category.Gameplay;
+    }
+
+    public virtual DisplayType GetDisplayType() => DisplayType.DropdownList;
 }

--- a/ModdingToolkit/CSharp/Client/Config/ConfigList.cs
+++ b/ModdingToolkit/CSharp/Client/Config/ConfigList.cs
@@ -33,8 +33,8 @@ public partial class ConfigList : IConfigList, INetConfigBase, IDisplayable
     public string ImageIcon { get; private set; }
     public Category MenuCategory { get; private set; }
 
-    public void InitializeDisplay(string name = "", string modName = "", string displayName = "", string displayModName = "",
-        string displayCategory = "", string tooltip = "", string imageIcon = "", Category menuCategory = Category.Gameplay)
+    public void InitializeDisplay(string? name = "", string? modName = "", string? displayName = "", string? displayModName = "",
+        string? displayCategory = "", string? tooltip = "", string? imageIcon = "", Category menuCategory = Category.Gameplay)
     {
         if (!displayName.IsNullOrWhiteSpace())
             this.DisplayName = displayName;

--- a/ModdingToolkit/CSharp/Client/Config/ConfigManager.cs
+++ b/ModdingToolkit/CSharp/Client/Config/ConfigManager.cs
@@ -18,6 +18,7 @@ public static partial class ConfigManager
         return CreateIConfigControl(name, modName, defaultValue, onValueChanged, filePathOverride);
     }
 
+    public static IEnumerable<IDisplayable> GetDisplayableConfigs() => Displayables.ToImmutableList();
     public static IEnumerable<DisplayableControl> GetControlConfigs() => DisplayableControls.ToImmutableList();
 
     #endregion
@@ -40,6 +41,10 @@ public static partial class ConfigManager
 
     private static void RegisterDisplayable(IDisplayable displayable, DisplayData data)
     {
+        #warning TODO: Implement display data verification
+        // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+        if (displayable is null)
+            return;
         if (data.MenuCategory is Category.Ignore)
             return;
         displayable.InitializeDisplay(data.Name, data.ModName, data.DisplayName, data.DisplayModName, 
@@ -67,13 +72,6 @@ public static partial class ConfigManager
 
     private static readonly List<IDisplayable> Displayables = new();
     private static readonly List<DisplayableControl> DisplayableControls = new();
-
-    /// <summary>
-    /// A pointer container to reduce type assignment checking at runtime. Both vars point to the same object.
-    /// </summary>
-    /// <param name="Displayable">The IDisplayable interface.</param>
-    /// <param name="Control">The IConfigControl interface.</param>
-    public record DisplayableControl(IDisplayable Displayable, IConfigControl Control);
 
     #endregion
 }

--- a/ModdingToolkit/CSharp/Client/Config/ConfigManager.cs
+++ b/ModdingToolkit/CSharp/Client/Config/ConfigManager.cs
@@ -7,6 +7,15 @@ public static partial class ConfigManager
 {
     #region PUBLIC_API
 
+    /// <summary>
+    /// Creates a Config var for binding key or mouse buttons to.
+    /// </summary>
+    /// <param name="name">Name of your config variable</param>
+    /// <param name="modName">The name of your Mod. Acts a collection everything with the same ModName.</param>
+    /// <param name="defaultValue">The default key or mouse binding.</param>
+    /// <param name="onValueChanged">Called whenever the value has been successfully changed.</param>
+    /// <param name="filePathOverride">Use if you want to load this variable from another config file on disk. Takes an absolute path.</param>
+    /// <returns></returns>
     public static IConfigControl AddConfigKeyOrMouseBind(
         string name,
         string modName,

--- a/ModdingToolkit/CSharp/Client/Config/ConfigManager.cs
+++ b/ModdingToolkit/CSharp/Client/Config/ConfigManager.cs
@@ -5,6 +5,8 @@ namespace ModdingToolkit.Config;
 
 public static partial class ConfigManager
 {
+    #region PUBLIC_API
+
     public static IConfigControl AddConfigKeyOrMouseBind(
         string name,
         string modName,
@@ -15,33 +17,63 @@ public static partial class ConfigManager
     {
         return CreateIConfigControl(name, modName, defaultValue, onValueChanged, filePathOverride);
     }
-    
-    public static IEnumerable<IConfigControl> GetControlConfigs()
-    {
-        List<IConfigControl> members = new();
-        Indexer_KeyMouseControls.ForEach(ci =>
-        {
-            if (LoadedConfigEntries.ContainsKey(ci.ModName) 
-                && LoadedConfigEntries[ci.ModName].ContainsKey(ci.Name)
-                && LoadedConfigEntries[ci.ModName][ci.Name] is IConfigControl icc)
-            {
-                members.Add(icc);   
-            }
-        });
-        return members;
-    }
-    
+
+    public static IEnumerable<DisplayableControl> GetControlConfigs() => DisplayableControls.ToImmutableList();
+
+    #endregion
+
+    #region INTERNAL_OPS
+
     private static IConfigControl CreateIConfigControl(
         string name,
         string modName,
         KeyOrMouse defaultValue,
         Action? onValueChanged,
-        string? filePathOverride = null)
+        string? filePathOverride = null,
+        DisplayData? data = null)
     {
         ConfigControl cc = new();
         cc.Initialize(name, modName, null, defaultValue, onValueChanged);
-        AddConfigToLists(cc);
-        LoadData(cc, filePathOverride);
+        InitializeConfigBase(cc, data, filePathOverride);
         return cc;
     }
+
+    private static void RegisterDisplayable(IDisplayable displayable, DisplayData data)
+    {
+        if (data.MenuCategory is Category.Ignore)
+            return;
+        displayable.InitializeDisplay(data.Name, data.ModName, data.DisplayName, data.DisplayModName, 
+            data.DisplayCategory, data.Tooltip, data.ImageIcon, data.MenuCategory);
+        Displayables.Add(displayable);
+        if (displayable is IConfigControl icc)
+            DisplayableControls.Add(new DisplayableControl(displayable, icc));
+    }
+
+    private static void RemoveDisplayable(IDisplayable displayable)
+    {
+        Displayables.RemoveAll(d => d == displayable);
+        DisplayableControls.RemoveAll(dc => dc.Displayable == displayable);
+    }
+
+    private static void DisposeClient()
+    {
+        Displayables.Clear();
+        DisplayableControls.Clear();
+    }
+
+    #endregion
+
+    #region INTERNAL VARS
+
+    private static readonly List<IDisplayable> Displayables = new();
+    private static readonly List<DisplayableControl> DisplayableControls = new();
+
+    /// <summary>
+    /// A pointer container to reduce type assignment checking at runtime. Both vars point to the same object.
+    /// </summary>
+    /// <param name="Displayable">The IDisplayable interface.</param>
+    /// <param name="Control">The IConfigControl interface.</param>
+    public record DisplayableControl(IDisplayable Displayable, IConfigControl Control);
+
+    #endregion
 }

--- a/ModdingToolkit/CSharp/Client/Config/ConfigRangeFloat.cs
+++ b/ModdingToolkit/CSharp/Client/Config/ConfigRangeFloat.cs
@@ -1,0 +1,6 @@
+﻿namespace ModdingToolkit.Config;
+
+public partial class ConfigRangeFloat : IDisplayable
+{
+    public override DisplayType GetDisplayType() => DisplayType.Slider;
+}

--- a/ModdingToolkit/CSharp/Client/Config/ConfigRangeInt.cs
+++ b/ModdingToolkit/CSharp/Client/Config/ConfigRangeInt.cs
@@ -1,0 +1,6 @@
+﻿namespace ModdingToolkit.Config;
+
+public partial class ConfigRangeInt : IDisplayable
+{
+    public override DisplayType GetDisplayType() => DisplayType.Slider;
+}

--- a/ModdingToolkit/CSharp/Client/Config/DisplayableControl.cs
+++ b/ModdingToolkit/CSharp/Client/Config/DisplayableControl.cs
@@ -1,0 +1,8 @@
+﻿namespace ModdingToolkit.Config;
+
+/// <summary>
+/// A pointer container to reduce type assignment checking at runtime. Both vars point to the same object.
+/// </summary>
+/// <param name="Displayable">The IDisplayable interface.</param>
+/// <param name="Control">The IConfigControl interface.</param>
+public record DisplayableControl(IDisplayable Displayable, IConfigControl Control);

--- a/ModdingToolkit/CSharp/Client/Config/IConfigControl.cs
+++ b/ModdingToolkit/CSharp/Client/Config/IConfigControl.cs
@@ -6,7 +6,8 @@ public interface IConfigControl : IConfigBase
 {
     KeyOrMouse? Value { get; set; }
     KeyOrMouse DefaultValue { get; }
-    void Initialize(string name, string modName, KeyOrMouse? currentValue, KeyOrMouse? defaultValue, System.Action? onValueChanged);
+    void Initialize(string name, string modName, KeyOrMouse? currentValue, KeyOrMouse? defaultValue, System.Action? onValueChanged,
+        string? displayName = null, string? displayModName = null, string? displayCategory = null);
     bool Validate(KeyOrMouse newValue);
     bool IsHit();
 }

--- a/ModdingToolkit/CSharp/Client/Config/IConfigControl.cs
+++ b/ModdingToolkit/CSharp/Client/Config/IConfigControl.cs
@@ -8,4 +8,5 @@ public interface IConfigControl : IConfigBase
     KeyOrMouse DefaultValue { get; }
     void Initialize(string name, string modName, KeyOrMouse? currentValue, KeyOrMouse? defaultValue, System.Action? onValueChanged);
     bool Validate(KeyOrMouse newValue);
+    bool IsHit();
 }

--- a/ModdingToolkit/CSharp/Client/Config/IConfigControl.cs
+++ b/ModdingToolkit/CSharp/Client/Config/IConfigControl.cs
@@ -6,8 +6,7 @@ public interface IConfigControl : IConfigBase
 {
     KeyOrMouse? Value { get; set; }
     KeyOrMouse DefaultValue { get; }
-    void Initialize(string name, string modName, KeyOrMouse? currentValue, KeyOrMouse? defaultValue, System.Action? onValueChanged,
-        string? displayName = null, string? displayModName = null, string? displayCategory = null);
+    void Initialize(string name, string modName, KeyOrMouse? currentValue, KeyOrMouse? defaultValue, System.Action? onValueChanged);
     bool Validate(KeyOrMouse newValue);
     bool IsHit();
 }

--- a/ModdingToolkit/CSharp/Client/Config/IDisplayable.cs
+++ b/ModdingToolkit/CSharp/Client/Config/IDisplayable.cs
@@ -1,0 +1,30 @@
+﻿namespace ModdingToolkit.Config;
+
+public interface IDisplayable
+{
+    string Name { get; }
+    string ModName { get; }
+    string DisplayName { get; }
+    string DisplayModName { get; }
+    string DisplayCategory { get; }
+    string Tooltip { get; }
+    string ImageIcon { get; }
+    Category MenuCategory { get; }
+
+    bool ValidateString(string value);
+    void SetValueAsDefault();
+    void SetValueFromString(string value);
+    string GetStringValue();
+    string GetStringDefaultValue();
+    DisplayType GetDisplayType();
+
+    void InitializeDisplay(
+        string? name = "",
+        string? modName = "",
+        string? displayName = "",
+        string? displayModName = "",
+        string? displayCategory = "",
+        string? tooltip = "",
+        string? imageIcon = "",
+        Category menuCategory = Category.Gameplay);
+}

--- a/ModdingToolkit/CSharp/Client/Networking/NetVar.cs
+++ b/ModdingToolkit/CSharp/Client/Networking/NetVar.cs
@@ -18,7 +18,7 @@ public sealed partial class NetVar<T> : INetVar<T> where T : IConvertible
     
     public void TriggerNetEvent()
     {
-        if (this.NetSync is NetworkSync.TwoWaySync)
+        if (NetSync is NetworkSync.TwoWaySync)
         {
             this._onNetworkEvent?.Invoke(this);
         } 

--- a/ModdingToolkit/CSharp/Client/Networking/NetVar.cs
+++ b/ModdingToolkit/CSharp/Client/Networking/NetVar.cs
@@ -1,0 +1,26 @@
+﻿namespace ModdingToolkit.Networking;
+
+public sealed partial class NetVar<T> : INetVar<T> where T : IConvertible
+{
+    public bool IsNetworked => this.NetSync != NetworkSync.NoSync && GameMain.IsMultiplayer;
+    public bool NetAuthorityValidate()
+    {
+        if (!IsNetworked)
+            return true;
+        return this.NetSync switch
+        {
+            NetworkSync.NoSync => true,
+            NetworkSync.ClientPermissiveDesync => true,
+            NetworkSync.TwoWaySync => true,
+            _ => false
+        };
+    }
+    
+    public void TriggerNetEvent()
+    {
+        if (this.NetSync is NetworkSync.TwoWaySync)
+        {
+            this._onNetworkEvent?.Invoke(this);
+        } 
+    }
+}

--- a/ModdingToolkit/CSharp/Client/Networking/NetworkingManager.cs
+++ b/ModdingToolkit/CSharp/Client/Networking/NetworkingManager.cs
@@ -142,11 +142,9 @@ public static partial class NetworkingManager
 
     public static void SynchronizeAll()
     {
-#if CLIENT
         if (!GameMain.IsMultiplayer)
             return;
-#endif
-        
+
         ClearNetworkData();
         SendRequestIdList();
     }

--- a/ModdingToolkit/CSharp/Client/Networking/NetworkingManager.cs
+++ b/ModdingToolkit/CSharp/Client/Networking/NetworkingManager.cs
@@ -105,8 +105,11 @@ public static partial class NetworkingManager
         try
         {
             uint id = msg.ReadUInt32();
-            if (TryGetNetConfigInstance(id, out var cfg))
+            if (TryGetNetConfigInstance(id, out var cfg)
+                && cfg!.NetSync is not NetworkSync.NoSync)
+            {
                 return cfg!.ReadNetworkValue(msg);
+            };
             return false;
         }
         catch (Exception e)

--- a/ModdingToolkit/CSharp/Client/Networking/NetworkingManager.cs
+++ b/ModdingToolkit/CSharp/Client/Networking/NetworkingManager.cs
@@ -142,6 +142,11 @@ public static partial class NetworkingManager
 
     public static void SynchronizeAll()
     {
+#if CLIENT
+        if (!GameMain.IsMultiplayer)
+            return;
+#endif
+        
         ClearNetworkData();
         SendRequestIdList();
     }

--- a/ModdingToolkit/CSharp/Server/Networking/NetVar.cs
+++ b/ModdingToolkit/CSharp/Server/Networking/NetVar.cs
@@ -1,0 +1,15 @@
+﻿namespace ModdingToolkit.Networking;
+
+public sealed partial class NetVar<T> : INetVar<T> where T : IConvertible
+{
+    public bool IsNetworked => this.NetSync != NetworkSync.NoSync;
+    public bool NetAuthorityValidate() => true;
+    
+    public void TriggerNetEvent()
+    {
+        if (this.NetSync is NetworkSync.TwoWaySync or NetworkSync.ServerAuthority or NetworkSync.ClientPermissiveDesync)
+        {
+            this._onNetworkEvent?.Invoke(this);
+        } 
+    }
+}

--- a/ModdingToolkit/CSharp/Server/Networking/NetworkingManager.cs
+++ b/ModdingToolkit/CSharp/Server/Networking/NetworkingManager.cs
@@ -147,15 +147,19 @@ public static partial class NetworkingManager
     {
         if (!IsInitialized)
             return;
+        if (!cfg.NetAuthorityValidate() || !cfg.IsNetworked)
+            return;
         if (TryGetNetId(cfg.NetId, out uint id))
         {
             var msg = PrepareWriteMessageWithHeaders(NetworkEventId.SyncVarSingle);
             msg.WriteUInt32(id);
-            cfg.WriteNetworkValue(msg);
-            if (client is null)
-                SendMsg(msg, null);
-            else
-                SendMsg(msg, client.Connection);
+            if (cfg.WriteNetworkValue(msg))
+            {
+                if (client is null)
+                    SendMsg(msg, null);
+                else
+                    SendMsg(msg, client.Connection);
+            }
         }
     }
 

--- a/ModdingToolkit/CSharp/Server/Networking/NetworkingManager.cs
+++ b/ModdingToolkit/CSharp/Server/Networking/NetworkingManager.cs
@@ -165,6 +165,8 @@ public static partial class NetworkingManager
 
     private static bool ReceiveSyncVarSingle(IReadMessage msg, Barotrauma.Networking.Client? client)
     {
+        if (client is null)
+            return false;
 #if DEBUG      
         Utils.Logging.PrintMessage($"ReceiveSyncVarSingle()");
 #endif
@@ -174,7 +176,9 @@ public static partial class NetworkingManager
             if (TryGetNetConfigInstance(id, out var cfg))
             {
                 // If bad read, retransmit the known good value to all clients.
-                if (!cfg!.ReadNetworkValue(msg))
+                if (cfg!.NetSync is NetworkSync.NoSync 
+                    || (cfg!.NetSync is NetworkSync.ServerAuthority && !client.HasPermission(ClientPermissions.ManageSettings))
+                    || !cfg!.ReadNetworkValue(msg))
                 {
                     SendNetSyncVarEvent(cfg);
                     return false;

--- a/ModdingToolkit/CSharp/Server/Networking/NetworkingManager.cs
+++ b/ModdingToolkit/CSharp/Server/Networking/NetworkingManager.cs
@@ -110,17 +110,17 @@ public static partial class NetworkingManager
                 TryGetNetConfigInstance(kvp.Value.ModName, kvp.Value.Name, out var cfg) 
                 && cfg is { IsNetworked: true })
             .ToImmutableDictionary();
-#if DEBUG
+    #if DEBUG
         Utils.Logging.PrintMessage($"NM::WriteIdListMsg() | SyncVar Count: {toSync.Count}");
-#endif
+    #endif
         foreach (var index in toSync)
         {
             var outmsg = PrepareWriteMessageWithHeaders(NetworkEventId.Client_RequestIdSingle);
             outmsg.WriteIdNameInfo(index.Key, index.Value.ModName, index.Value.Name);
             SendMsg(outmsg, client.Connection);
-#if DEBUG
+    #if DEBUG
             Utils.Logging.PrintMessage($"NM::WriteIdListMsg() | Writing SyncVar: id={index.Key}, modName={index.Value.ModName}, name={index.Value.Name}");
-#endif
+    #endif
         }
     }
 

--- a/ModdingToolkit/CSharp/Shared/Bootloader.cs
+++ b/ModdingToolkit/CSharp/Shared/Bootloader.cs
@@ -168,8 +168,10 @@ internal sealed class Bootloader : ACsMod
         // Statics
         UserData.RegisterType(typeof(ConfigManager));
         UserData.RegisterType(typeof(NetworkingManager));
+        UserData.RegisterType(typeof(MemoryCallbackCache));
         GameMain.LuaCs.Lua.Globals[nameof(ConfigManager)] = UserData.CreateStatic(typeof(ConfigManager));
         GameMain.LuaCs.Lua.Globals[nameof(NetworkingManager)] = UserData.CreateStatic(typeof(NetworkingManager));
+        GameMain.LuaCs.Lua.Globals[nameof(MemoryCallbackCache)] = UserData.CreateStatic(typeof(MemoryCallbackCache));
     }
 
     private void DeregisterLua()
@@ -178,8 +180,10 @@ internal sealed class Bootloader : ACsMod
         // Statics
         GameMain.LuaCs.Lua.Globals[nameof(ConfigManager)] = null;
         GameMain.LuaCs.Lua.Globals[nameof(NetworkingManager)] = null;
+        GameMain.LuaCs.Lua.Globals[nameof(MemoryCallbackCache)] = null;
         UserData.UnregisterType(typeof(NetworkingManager));
         UserData.UnregisterType(typeof(ConfigManager));
+        UserData.UnregisterType(typeof(MemoryCallbackCache));
 
 #if CLIENT
         UserData.RegisterType<IDisplayable>();

--- a/ModdingToolkit/CSharp/Shared/Bootloader.cs
+++ b/ModdingToolkit/CSharp/Shared/Bootloader.cs
@@ -163,6 +163,7 @@ internal sealed class Bootloader : ACsMod
 #if CLIENT
         UserData.RegisterType<IConfigControl>();
         UserData.RegisterType<ConfigControl>();
+        UserData.RegisterType<IDisplayable>();
 #endif
         // Statics
         UserData.RegisterType(typeof(ConfigManager));
@@ -181,6 +182,7 @@ internal sealed class Bootloader : ACsMod
         UserData.UnregisterType(typeof(ConfigManager));
 
 #if CLIENT
+        UserData.RegisterType<IDisplayable>();
         UserData.UnregisterType<ConfigControl>();
         UserData.UnregisterType<IConfigControl>();
 #endif

--- a/ModdingToolkit/CSharp/Shared/Bootloader.cs
+++ b/ModdingToolkit/CSharp/Shared/Bootloader.cs
@@ -26,43 +26,15 @@ internal sealed class Bootloader : ACsMod
         LoadPatches();
         RegisterCommands();
         ConsoleCommands.ReloadAllCommands();
-        NetworkingManager.SynchronizeAll();
+#if CLIENT
+        if (GameMain.IsMultiplayer)
+            NetworkingManager.SynchronizeAll();        
+#endif
         IsLoaded = true;
     }
 
     private void RegisterCommands()
     {
-        // TODO: Fix console commands. This is disabled as unloading plugins requires unloading and reloading Config and Networking but there is no way to ensure compliance from ContentPackage mods. This will just leads to runtime errors for end-users.
-        /*ConsoleCommands.RegisterCommand(
-            "cl_reloadassemblies", 
-            "Reloads all assemblies and their plugins.",
-            _ =>
-            {
-                ConfigManager.Dispose();
-                NetworkingManager.Dispose();
-                XMLDocumentHelper.UnloadCache();
-                UnloadPatches();
-                PatchManager.Dispose();
-                PluginHelper.UnloadAssemblies();
-                PluginHelper.LoadAssemblies();
-                NetworkingManager.Initialize(true);
-                NetworkingManager.SynchronizeAll();
-                LoadPatches();
-            });
-        
-        ConsoleCommands.RegisterCommand(
-            "cl_unloadassemblies", 
-            "Unloads all assemblies and their plugins.",
-            _ =>
-            {
-                ConfigManager.Dispose();
-                NetworkingManager.Dispose();
-                XMLDocumentHelper.UnloadCache();
-                UnloadPatches();
-                PatchManager.Dispose();
-                PluginHelper.UnloadAssemblies();
-            });*/
-        
         ConsoleCommands.RegisterCommand(
             "cl_cfgsetvar",
             "Sets a config member to the supplied string. Format is <command> <modname> <name> \"<value>\"",
@@ -168,8 +140,9 @@ internal sealed class Bootloader : ACsMod
         UserData.RegisterType<IConfigRangeInt>();
         
         // Types
+        UserData.RegisterType<DisplayData>();
         UserData.RegisterType<NetworkSync>();
-        UserData.RegisterType<IConfigBase.DisplayType>();
+        UserData.RegisterType<DisplayType>();
         
         UserData.RegisterType<ConfigEntry<bool>>();
         UserData.RegisterType<ConfigEntry<byte>>();
@@ -229,7 +202,8 @@ internal sealed class Bootloader : ACsMod
         UserData.UnregisterType<ConfigEntry<string>>();
         
         UserData.UnregisterType<NetworkSync>();
-        UserData.UnregisterType<IConfigBase.DisplayType>();
+        UserData.UnregisterType<DisplayType>();
+        UserData.UnregisterType<DisplayData>();
         
         // Interfaces
         UserData.UnregisterType<IConfigList>();

--- a/ModdingToolkit/CSharp/Shared/Config/ConfigEntry.cs
+++ b/ModdingToolkit/CSharp/Shared/Config/ConfigEntry.cs
@@ -36,8 +36,6 @@ public partial class ConfigEntry<T> : IConfigEntry<T>, INetConfigBase where T : 
     }
 
     public T DefaultValue { get; private set; } = default!;
-
-    public IConfigEntry<T>.Category MenuCategory { get; private set; }
     public NetworkSync NetSync { get; private set; }
 
     public void SetNetworkingId(Guid id)
@@ -50,9 +48,7 @@ public partial class ConfigEntry<T> : IConfigEntry<T>, INetConfigBase where T : 
     // ReSharper disable once UnusedAutoPropertyAccessor.Global
     public bool IsInitialized { get; private set; } = false;
 
-    public virtual void Initialize(string name, string modName, T newValue, T defaultValue, 
-        NetworkSync sync = NetworkSync.NoSync, 
-        IConfigBase.Category menuCategory = IConfigBase.Category.Gameplay, 
+    public virtual void Initialize(string name, string modName, T newValue, T defaultValue,
         Func<T, bool>? valueChangePredicate = null,
         Action<IConfigEntry<T>>? onValueChanged = null)
     {
@@ -65,8 +61,7 @@ public partial class ConfigEntry<T> : IConfigEntry<T>, INetConfigBase where T : 
         this.ModName = modName;
         this.DefaultValue = defaultValue;
         this._value = this.Validate(newValue) ? newValue : this.DefaultValue;
-        this.NetSync = sync;
-        this.MenuCategory = menuCategory;
+
         if (valueChangePredicate is not null)
             this._valueChangePredicate = valueChangePredicate;
         if (onValueChanged is not null)
@@ -112,15 +107,6 @@ public partial class ConfigEntry<T> : IConfigEntry<T>, INetConfigBase where T : 
         this.Value = this.DefaultValue;
     }
 
-    public virtual IConfigBase.DisplayType GetDisplayType() =>
-        typeof(T) switch
-        {
-            { IsEnum: true } => IConfigBase.DisplayType.DropdownEnum,
-            { Name: nameof(Boolean) } => IConfigBase.DisplayType.Tickbox,
-            { IsPrimitive: true } => IConfigBase.DisplayType.Number,
-            _ => IConfigBase.DisplayType.Standard
-        };
-
     public bool ValidateString(string value)
     {
         try
@@ -160,5 +146,11 @@ public partial class ConfigEntry<T> : IConfigEntry<T>, INetConfigBase where T : 
     void INetConfigBase.UnsubscribeFromNetEvents(Action<INetConfigBase> evtHandle)
     {
         this._onNetworkEvent -= evtHandle;
+    }
+
+    public void InitializeNetworking(Guid netId, NetworkSync networkSync)
+    {
+        this.NetId = netId;
+        this.NetSync = networkSync;
     }
 }

--- a/ModdingToolkit/CSharp/Shared/Config/ConfigEntry.cs
+++ b/ModdingToolkit/CSharp/Shared/Config/ConfigEntry.cs
@@ -16,10 +16,13 @@ public partial class ConfigEntry<T> : IConfigEntry<T>, INetConfigBase where T : 
     #endregion
 
     public string Name { get; private set; } = String.Empty;
-
+    public string DisplayName { get; private set; } = String.Empty;
+    public string ModName { get; private set; } = String.Empty;
+    public string DisplayModName { get; private set; } = String.Empty;
+    public string DisplayCategory { get; private set; } = String.Empty;
+    
     public Type SubTypeDef => typeof(T);
     public Type NetSyncVarTypeDef => typeof(T);
-    public string ModName { get; private set; } = String.Empty;
 
     public virtual T Value
     {
@@ -54,7 +57,10 @@ public partial class ConfigEntry<T> : IConfigEntry<T>, INetConfigBase where T : 
         NetworkSync sync = NetworkSync.NoSync, 
         IConfigBase.Category menuCategory = IConfigBase.Category.Gameplay, 
         Func<T, bool>? valueChangePredicate = null,
-        Action<IConfigEntry<T>>? onValueChanged = null)
+        Action<IConfigEntry<T>>? onValueChanged = null,
+        string? displayName = null,
+        string? displayModName = null,
+        string? displayCategory = null)
     {
         if (name.Trim().IsNullOrEmpty())
             throw new ArgumentNullException($"ConfigEntry<{typeof(T).Name}>::Initialize() | Name is null or empty.");
@@ -67,6 +73,15 @@ public partial class ConfigEntry<T> : IConfigEntry<T>, INetConfigBase where T : 
         this._value = this.Validate(newValue) ? newValue : this.DefaultValue;
         this.NetSync = sync;
         this.MenuCategory = menuCategory;
+        
+        // Client menu data
+        if (displayName is not null)
+            this.DisplayName = displayName;
+        if (displayModName is not null)
+            this.DisplayModName = displayModName;
+        if (displayCategory is not null)
+            this.DisplayCategory = displayCategory;
+        
         if (valueChangePredicate is not null)
             this._valueChangePredicate = valueChangePredicate;
         if (onValueChanged is not null)

--- a/ModdingToolkit/CSharp/Shared/Config/ConfigEntry.cs
+++ b/ModdingToolkit/CSharp/Shared/Config/ConfigEntry.cs
@@ -122,27 +122,12 @@ public partial class ConfigEntry<T> : IConfigEntry<T>, INetConfigBase where T : 
 
     bool INetConfigBase.WriteNetworkValue(IWriteMessage msg)
     {
-#if SERVER
-        if (NetSync is NetworkSync.NoSync)
-            return false;
-#else
-        if (NetSync is NetworkSync.ServerAuthority or NetworkSync.ClientPermissiveDesync or NetworkSync.NoSync)
-            return false;
-#endif
         Utils.Networking.WriteNetValueFromType(msg, this.Value);
         return true;
     }
 
     bool INetConfigBase.ReadNetworkValue(IReadMessage msg)
     {
-#if SERVER
-        if (NetSync is NetworkSync.ServerAuthority or NetworkSync.ClientPermissiveDesync or NetworkSync.NoSync)
-            return false;
-#else
-        if (NetSync is NetworkSync.NoSync)
-            return false;
-#endif
-        
         try
         {
             T value = Utils.Networking.ReadNetValueFromType<T>(msg);

--- a/ModdingToolkit/CSharp/Shared/Config/ConfigList.cs
+++ b/ModdingToolkit/CSharp/Shared/Config/ConfigList.cs
@@ -16,6 +16,10 @@ public partial class ConfigList : IConfigList, INetConfigBase
     #endregion
 
     public string Name { get; private set; } = String.Empty;
+    public string DisplayName { get; private set; } = String.Empty;
+    public string ModName { get; private set; } = String.Empty;
+    public string DisplayModName { get; private set; } = String.Empty;
+    public string DisplayCategory { get; private set; } = String.Empty;
 
     public Type SubTypeDef => typeof(string);
     public Type NetSyncVarTypeDef => typeof(ushort);
@@ -25,7 +29,6 @@ public partial class ConfigList : IConfigList, INetConfigBase
     }
 
     public Guid NetId { get; private set; }
-    public string ModName { get; private set; } = String.Empty;
     
     public virtual string Value
     {
@@ -47,7 +50,8 @@ public partial class ConfigList : IConfigList, INetConfigBase
     
     public void Initialize(string name, string modName, string newValue, string defaultValue, List<string> valueList,
         NetworkSync sync = NetworkSync.NoSync, IConfigBase.Category menuCategory = IConfigBase.Category.Gameplay,
-        Func<string, bool>? valueChangePredicate = null, Action<IConfigList>? onValueChanged = null)
+        Func<string, bool>? valueChangePredicate = null, Action<IConfigList>? onValueChanged = null,
+        string? displayName = null, string? displayModName = null, string? displayCategory = null)
     {
         if (name.Trim().IsNullOrEmpty())
             throw new ArgumentNullException($"ConfigEntry<string>::Initialize() | Name is null or empty.");
@@ -61,6 +65,14 @@ public partial class ConfigList : IConfigList, INetConfigBase
         this.MenuCategory = menuCategory;
         this._valueList = valueList.ToImmutableList();
 
+        // Client menu data
+        if (displayName is not null)
+            this.DisplayName = displayName;
+        if (displayModName is not null)
+            this.DisplayModName = displayModName;
+        if (displayCategory is not null)
+            this.DisplayCategory = displayCategory;
+        
         if (this._valueList.Count < 1)
             this._valueList = new List<string> { "" }.ToImmutableList();    //Empty lists not allowed to reduce overhead elsewhere.
         

--- a/ModdingToolkit/CSharp/Shared/Config/ConfigList.cs
+++ b/ModdingToolkit/CSharp/Shared/Config/ConfigList.cs
@@ -113,12 +113,26 @@ public partial class ConfigList : IConfigList, INetConfigBase
 
     bool INetConfigBase.WriteNetworkValue(IWriteMessage msg)
     {
+#if SERVER
+        if (NetSync is NetworkSync.NoSync)
+            return false;
+#else
+        if (NetSync is NetworkSync.ServerAuthority or NetworkSync.ClientPermissiveDesync or NetworkSync.NoSync)
+            return false;
+#endif
         Utils.Networking.WriteNetValueFromType(msg, (ushort)_valueList.IndexOf(_value));
         return true;
     }
 
     bool INetConfigBase.ReadNetworkValue(IReadMessage msg)
     {
+#if SERVER
+        if (NetSync is NetworkSync.ServerAuthority or NetworkSync.ClientPermissiveDesync or NetworkSync.NoSync)
+            return false;
+#else
+        if (NetSync is NetworkSync.NoSync)
+            return false;
+#endif
         ushort val = Utils.Networking.ReadNetValueFromType<ushort>(msg);
         if (val >= _valueList.Count)
         {

--- a/ModdingToolkit/CSharp/Shared/Config/ConfigList.cs
+++ b/ModdingToolkit/CSharp/Shared/Config/ConfigList.cs
@@ -46,7 +46,6 @@ public partial class ConfigList : IConfigList, INetConfigBase
     public ref readonly ImmutableList<string> GetReadOnlyList() => ref _valueList;
     
     public void Initialize(string name, string modName, string newValue, string defaultValue, List<string> valueList,
-        NetworkSync sync = NetworkSync.NoSync, IConfigBase.Category menuCategory = IConfigBase.Category.Gameplay,
         Func<string, bool>? valueChangePredicate = null, Action<IConfigList>? onValueChanged = null)
     {
         if (name.Trim().IsNullOrEmpty())
@@ -57,8 +56,6 @@ public partial class ConfigList : IConfigList, INetConfigBase
         this.Name = name;
         this.ModName = modName;
 
-        this.NetSync = sync;
-        this.MenuCategory = menuCategory;
         this._valueList = valueList.ToImmutableList();
 
         if (this._valueList.Count < 1)
@@ -77,7 +74,6 @@ public partial class ConfigList : IConfigList, INetConfigBase
         this.IsInitialized = true;
     }
 
-    public IConfigEntry<string>.Category MenuCategory { get; private set; }
     public NetworkSync NetSync { get; private set; }
 
     public bool IsInitialized { get; private set; } = false;
@@ -113,7 +109,6 @@ public partial class ConfigList : IConfigList, INetConfigBase
         this.Value = this.DefaultValue;
     }
 
-    public virtual IConfigBase.DisplayType GetDisplayType() => IConfigBase.DisplayType.DropdownList;
     public bool ValidateString(string value) => Validate(value);
 
     bool INetConfigBase.WriteNetworkValue(IWriteMessage msg)
@@ -143,5 +138,11 @@ public partial class ConfigList : IConfigList, INetConfigBase
     void INetConfigBase.UnsubscribeFromNetEvents(Action<INetConfigBase> evtHandle)
     {
         this._onNetworkEvent -= evtHandle;
+    }
+
+    public void InitializeNetworking(Guid netId, NetworkSync networkSync)
+    {
+        this.NetId = netId;
+        this.NetSync = networkSync;
     }
 }

--- a/ModdingToolkit/CSharp/Shared/Config/ConfigList.cs
+++ b/ModdingToolkit/CSharp/Shared/Config/ConfigList.cs
@@ -113,26 +113,12 @@ public partial class ConfigList : IConfigList, INetConfigBase
 
     bool INetConfigBase.WriteNetworkValue(IWriteMessage msg)
     {
-#if SERVER
-        if (NetSync is NetworkSync.NoSync)
-            return false;
-#else
-        if (NetSync is NetworkSync.ServerAuthority or NetworkSync.ClientPermissiveDesync or NetworkSync.NoSync)
-            return false;
-#endif
         Utils.Networking.WriteNetValueFromType(msg, (ushort)_valueList.IndexOf(_value));
         return true;
     }
 
     bool INetConfigBase.ReadNetworkValue(IReadMessage msg)
     {
-#if SERVER
-        if (NetSync is NetworkSync.ServerAuthority or NetworkSync.ClientPermissiveDesync or NetworkSync.NoSync)
-            return false;
-#else
-        if (NetSync is NetworkSync.NoSync)
-            return false;
-#endif
         ushort val = Utils.Networking.ReadNetValueFromType<ushort>(msg);
         if (val >= _valueList.Count)
         {

--- a/ModdingToolkit/CSharp/Shared/Config/ConfigManager.cs
+++ b/ModdingToolkit/CSharp/Shared/Config/ConfigManager.cs
@@ -49,20 +49,20 @@ public static partial class ConfigManager
     /// <param name="onValueChanged">Called whenever the value has been successfully changed.</param>
     /// <param name="validateNewInput">Allows you to validate any potential changes to the Value. Return false to deny.</param>
     /// <param name="filePathOverride">Use if you want to load this variable from another config file on disk. Takes an absolute path.</param>
+    /// <param name="displayData">Contains data used for Settings Menu entries or other GUI functions. Not used on server.</param>
     /// <typeparam name="T">The Value's Type</typeparam>
     /// <returns>[CanBeNull] Returns the Config Member instance or null if failed.</returns>
     public static IConfigEntry<T> AddConfigEntry<T>(
         string name,
         string modName,
         T defaultValue,
-        IConfigBase.Category menuCategory = IConfigBase.Category.Gameplay,
         NetworkSync networkSync = NetworkSync.NoSync,
         Action<IConfigEntry<T>>? onValueChanged = null,
         Func<T, bool>? validateNewInput = null,
-        string? filePathOverride = null) where T : IConvertible
+        string? filePathOverride = null, DisplayData? displayData = null) where T : IConvertible
     {
-        return CreateIConfigEntry(name, modName, defaultValue, menuCategory, networkSync, onValueChanged,
-            validateNewInput, filePathOverride);
+        return CreateIConfigEntry(name, modName, defaultValue, networkSync, onValueChanged,
+            validateNewInput, filePathOverride, displayData);
     }
 
     /// <summary>
@@ -78,19 +78,19 @@ public static partial class ConfigManager
     /// <param name="valueChangePredicate">Allows you to validate any potential changes to the Value. Return false to deny.</param>
     /// <param name="onValueChanged">Called whenever the value has been successfully changed.</param>
     /// <param name="filePathOverride">Use if you want to load this variable from another config file on disk. Takes an absolute path.</param>
+    /// <param name="displayData">Contains data used for Settings Menu entries or other GUI functions. Not used on server.</param>
     /// <returns>[CanBeNull] Returns the Config Member instance or null if failed.</returns>
     public static IConfigList AddConfigList(
-        string name, string modName, 
+        string name, string modName,
         string defaultValue,
         List<string> valueList,
         NetworkSync networkSync = NetworkSync.NoSync,
-        IConfigBase.Category menuCategory = IConfigBase.Category.Gameplay,
         Func<string, bool>? valueChangePredicate = null,
         Action<IConfigList>? onValueChanged = null,
-        string? filePathOverride = null)
+        string? filePathOverride = null, DisplayData? displayData = null)
     {
         return CreateIConfigList(name, modName, defaultValue, valueList, networkSync, 
-            menuCategory, valueChangePredicate, onValueChanged, filePathOverride);
+            valueChangePredicate, onValueChanged, filePathOverride, displayData);
     }
 
     /// <summary>
@@ -108,18 +108,18 @@ public static partial class ConfigManager
     /// <param name="valueChangePredicate">Allows you to validate any potential changes to the Value. Return false to deny.</param>
     /// <param name="onValueChanged">Called whenever the value has been successfully changed.</param>
     /// <param name="filePathOverride">Use if you want to load this variable from another config file on disk. Takes an absolute path.</param>
+    /// <param name="displayData">Contains data used for Settings Menu entries or other GUI functions. Not used on server.</param>
     /// <returns>[CanBeNull] Returns the Config Member instance or null if failed.</returns>
     public static IConfigRangeInt AddConfigRangeInt(
         string name, string modName,
         int defaultValue, int minValue, int maxValue, int steps,
         NetworkSync networkSync = NetworkSync.NoSync,
-        IConfigBase.Category menuCategory = IConfigBase.Category.Gameplay,
         Func<int, bool>? valueChangePredicate = null,
         Action<IConfigRangeInt>? onValueChanged = null,
-        string? filePathOverride = null)
+        string? filePathOverride = null, DisplayData? displayData = null)
     {
-        return CreateIConfigRangeInt(name, modName, defaultValue, minValue, maxValue, steps, networkSync, menuCategory,
-            valueChangePredicate, onValueChanged, filePathOverride);
+        return CreateIConfigRangeInt(name, modName, defaultValue, minValue, maxValue, steps, networkSync,
+            valueChangePredicate, onValueChanged, filePathOverride, displayData);
     }
     
     /// <summary>
@@ -137,18 +137,19 @@ public static partial class ConfigManager
     /// <param name="valueChangePredicate">Allows you to validate any potential changes to the Value. Return false to deny.</param>
     /// <param name="onValueChanged">Called whenever the value has been successfully changed.</param>
     /// <param name="filePathOverride">Use if you want to load this variable from another config file on disk. Takes an absolute path.</param>
+    /// <param name="displayData">Contains data used for Settings Menu entries or other GUI functions. Not used on server.</param>
     /// <returns>[CanBeNull] Returns the Config Member instance or null if failed.</returns>
     public static IConfigRangeFloat AddConfigRangeFloat(
         string name, string modName,
         float defaultValue, float minValue, float maxValue, int steps,
         NetworkSync networkSync = NetworkSync.NoSync,
-        IConfigBase.Category menuCategory = IConfigBase.Category.Gameplay,
         Func<float, bool>? valueChangePredicate = null,
         Action<IConfigRangeFloat>? onValueChanged = null,
-        string? filePathOverride = null)
+        string? filePathOverride = null,
+        DisplayData? displayData = null)
     {
-        return CreateIConfigRangeFloat(name, modName, defaultValue, minValue, maxValue, steps, networkSync, menuCategory,
-            valueChangePredicate, onValueChanged, filePathOverride);
+        return CreateIConfigRangeFloat(name, modName, defaultValue, minValue, maxValue, steps, networkSync,
+            valueChangePredicate, onValueChanged, filePathOverride, displayData);
     }
 
     /// <summary>
@@ -243,48 +244,6 @@ public static partial class ConfigManager
         }
     }
 
-    /// <summary>
-    /// Returns a collection of config members under a given menu category.
-    /// </summary>
-    /// <param name="category">The menu category.</param>
-    /// <returns>Enumerator for iteration.</returns>
-    public static IEnumerable<IConfigBase> GetConfigMembers(IConfigBase.Category category)
-    {
-        if (!Indexer_MenuCategory.ContainsKey(category))
-            return new List<IConfigBase>();
-        List<IConfigBase> members = new();
-        Indexer_MenuCategory[category].ForEach(ci =>
-        {
-            if (LoadedConfigEntries.ContainsKey(ci.ModName) 
-                && LoadedConfigEntries[ci.ModName].ContainsKey(ci.Name))
-            {
-                members.Add(LoadedConfigEntries[ci.ModName][ci.Name]);
-            }
-        });
-        return members;
-    }
-
-    /// <summary>
-    /// Returns a collection of config members under a given network sync category.
-    /// </summary>
-    /// <param name="networkSync">The sync setting.</param>
-    /// <returns>Enumerator for iteration.</returns>
-    public static IEnumerable<IConfigBase> GetConfigMembers(NetworkSync networkSync)
-    {
-        if (!Indexer_NetSync.ContainsKey(networkSync))
-            return new List<IConfigBase>();
-        List<IConfigBase> members = new();
-        Indexer_NetSync[networkSync].ForEach(ci =>
-        {
-            if (LoadedConfigEntries.ContainsKey(ci.ModName) 
-                && LoadedConfigEntries[ci.ModName].ContainsKey(ci.Name))
-            {
-                members.Add(LoadedConfigEntries[ci.ModName][ci.Name]);
-            }
-        });
-        return members;
-    }
-
     #endregion
 
     #region Helper_Extensions
@@ -293,38 +252,34 @@ public static partial class ConfigManager
      */
     
     public static IConfigEntry<double> AddConfigDouble(string name, string modName, double defaultValue,
-        IConfigBase.Category menuCategory = IConfigBase.Category.Gameplay,
         NetworkSync networkSync = NetworkSync.NoSync,
         Action<IConfigEntry<double>>? onValueChanged = null, 
         Func<double, bool>? validateNewInput = null, 
-        string? filePath = null)
-        => AddConfigEntry(name, modName, defaultValue, menuCategory, networkSync, onValueChanged, validateNewInput, filePath);
+        string? filePath = null, DisplayData? data = null)
+        => AddConfigEntry(name, modName, defaultValue, networkSync, onValueChanged, validateNewInput, filePath, data);
     
     public static IConfigEntry<string> AddConfigString(string name, string modName, string defaultValue,
-        IConfigBase.Category menuCategory = IConfigBase.Category.Gameplay,
         NetworkSync networkSync = NetworkSync.NoSync,
         Action<IConfigEntry<string>>? onValueChanged = null, 
         Func<string, bool>? validateNewInput = null, 
-        string? filePath = null)
-        => AddConfigEntry(name, modName, defaultValue, menuCategory, networkSync, onValueChanged, validateNewInput, filePath);
+        string? filePath = null, DisplayData? data = null)
+        => AddConfigEntry(name, modName, defaultValue, networkSync, onValueChanged, validateNewInput, filePath, data);
 
     
     public static IConfigEntry<bool> AddConfigBoolean(string name, string modName, bool defaultValue,
-        IConfigBase.Category menuCategory = IConfigBase.Category.Gameplay,
         NetworkSync networkSync = NetworkSync.NoSync,
         Action<IConfigEntry<bool>>? onValueChanged = null, 
         Func<bool, bool>? validateNewInput = null, 
-        string? filePath = null)
-        => AddConfigEntry(name, modName, defaultValue, menuCategory, networkSync, onValueChanged, validateNewInput, filePath);
+        string? filePath = null, DisplayData? data = null)
+        => AddConfigEntry(name, modName, defaultValue, networkSync, onValueChanged, validateNewInput, filePath, data);
 
     
     public static IConfigEntry<int> AddConfigInteger(string name, string modName, int defaultValue,
-        IConfigBase.Category menuCategory = IConfigBase.Category.Gameplay,
         NetworkSync networkSync = NetworkSync.NoSync,
         Action<IConfigEntry<int>>? onValueChanged = null, 
         Func<int, bool>? validateNewInput = null, 
-        string? filePath = null)
-        => AddConfigEntry(name, modName, defaultValue, menuCategory, networkSync, onValueChanged, validateNewInput, filePath);
+        string? filePath = null, DisplayData? data = null)
+        => AddConfigEntry(name, modName, defaultValue, networkSync, onValueChanged, validateNewInput, filePath, data);
 
     #endregion
 
@@ -335,36 +290,29 @@ public static partial class ConfigManager
         string name,
         string modName,
         T defaultValue,
-        IConfigBase.Category menuCategory,
         NetworkSync networkSync,
         Action<IConfigEntry<T>>? onValueChanged,
         Func<T, bool>? validateNewInput,
-        string? filePathOverride = null
+        string? filePathOverride = null,
+        DisplayData? data = null
         ) where T : IConvertible
     {
         ConfigEntry<T> ce = new();
-        ce.Initialize(name, modName, defaultValue, defaultValue, networkSync, menuCategory, validateNewInput, onValueChanged);
-        AddConfigToLists(ce);
-        LoadData(ce, filePathOverride);
-        if (ce is INetConfigBase ince)
-            RegisterForNetworking(ince);
+        ce.Initialize(name, modName, defaultValue, defaultValue, validateNewInput, onValueChanged);
+        InitializeConfigBase(ce, data, filePathOverride, networkSync);
         return ce;
     }
 
     private static IConfigList CreateIConfigList(string name, string modName, string defaultValue,
         List<string> valueList,
         NetworkSync sync = NetworkSync.NoSync,
-        IConfigBase.Category menuCategory = IConfigBase.Category.Gameplay,
         Func<string, bool>? valueChangePredicate = null,
         Action<IConfigList>? onValueChanged = null,
-        string? filePathOverride = null)
+        string? filePathOverride = null, DisplayData? data = null)
     {
         ConfigList cl = new();
-        cl.Initialize(name, modName, defaultValue, defaultValue, valueList, sync, menuCategory, valueChangePredicate, onValueChanged);
-        AddConfigToLists(cl);
-        LoadData(cl, filePathOverride);
-        if (cl is INetConfigBase ince)
-            RegisterForNetworking(ince);
+        cl.Initialize(name, modName, defaultValue, defaultValue, valueList, valueChangePredicate, onValueChanged);
+        InitializeConfigBase(cl, data, filePathOverride, sync);
         return cl;
     }
     
@@ -372,17 +320,13 @@ public static partial class ConfigManager
         string name, string modName,
         int defaultValue, int minValue, int maxValue, int steps,
         NetworkSync sync = NetworkSync.NoSync,
-        IConfigBase.Category menuCategory = IConfigBase.Category.Gameplay,
         Func<int, bool>? valueChangePredicate = null,
         Action<IConfigRangeInt>? onValueChanged = null,
-        string? filePathOverride = null)
+        string? filePathOverride = null, DisplayData? data = null)
     {
         ConfigRangeInt cr = new();
-        cr.Initialize(name, modName, defaultValue, defaultValue, minValue, maxValue, steps, sync, menuCategory, valueChangePredicate);
-        AddConfigToLists(cr);
-        LoadData(cr, filePathOverride);
-        if (cr is INetConfigBase ince)
-            RegisterForNetworking(ince);
+        cr.Initialize(name, modName, defaultValue, defaultValue, minValue, maxValue, steps, valueChangePredicate);
+        InitializeConfigBase(cr, data, filePathOverride, sync);
         return cr;
     }
 
@@ -390,17 +334,13 @@ public static partial class ConfigManager
         string name, string modName,
         float defaultValue, float minValue, float maxValue, int steps,
         NetworkSync sync = NetworkSync.NoSync,
-        IConfigBase.Category menuCategory = IConfigBase.Category.Gameplay,
         Func<float, bool>? valueChangePredicate = null,
         Action<IConfigRangeFloat>? onValueChanged = null,
-        string? filePathOverride = null)
+        string? filePathOverride = null, DisplayData? data = null)
     {
         ConfigRangeFloat cr = new();
-        cr.Initialize(name, modName, defaultValue, defaultValue, minValue, maxValue, steps, sync, menuCategory, valueChangePredicate);
-        AddConfigToLists(cr);
-        LoadData(cr, filePathOverride);
-        if (cr is INetConfigBase ince)
-            RegisterForNetworking(ince);
+        cr.Initialize(name, modName, defaultValue, defaultValue, minValue, maxValue, steps, valueChangePredicate);
+        InitializeConfigBase(cr, data, filePathOverride, sync);
         return cr;
     }
 
@@ -441,10 +381,10 @@ public static partial class ConfigManager
 
         LoadedConfigEntries.Clear();
         LoadedXDocKeys.Clear();
-        Indexer_MenuCategory.Clear();
-        Indexer_NetSync.Clear();
         Indexer_AllLoadedEntries.Clear();
-        
+#if CLIENT
+        DisposeClient();
+#endif
         CleanupEvents();
     }
 
@@ -470,6 +410,19 @@ public static partial class ConfigManager
     
     #region INTERNAL_OPERATIONS
 
+    private static void InitializeConfigBase(IConfigBase cfg, DisplayData? displayData, string? filePathOverride = null,
+        NetworkSync syncMode = NetworkSync.NoSync)
+    {
+        AddConfigToLists(cfg);
+        LoadData(cfg, filePathOverride);
+#if CLIENT
+        if (cfg is IDisplayable displayable && displayData is not null)
+            RegisterDisplayable(displayable, displayData);
+#endif
+        if (cfg is INetConfigBase inc)
+            RegisterForNetworking(inc, syncMode);
+    }
+    
     #region LOCAL_IO
     private static bool SaveData(IConfigBase config)
     {
@@ -672,21 +625,11 @@ public static partial class ConfigManager
 
     #region NETWORKING
 
-    private static void RegisterForNetworking(INetConfigBase cfg)
+    private static void RegisterForNetworking(INetConfigBase cfg, NetworkSync syncMode)
     {
-        if (!GameMain.IsMultiplayer || cfg.NetSync is NetworkSync.NoSync)
+        if (!GameMain.IsMultiplayer || syncMode is NetworkSync.NoSync)
             return;
-        if (!NetworkingManager.RegisterNetConfigInstance(cfg))
-        {
-            Utils.Logging.PrintError($"Network Registration for {cfg.ModName} {cfg.Name} failed.");
-        }
-    }
-
-    private static void RegisterForNetworking<T>(INetConfigBase cfg) where T : IConvertible
-    {
-        if (!GameMain.IsMultiplayer || cfg.NetSync == NetworkSync.NoSync)
-            return;
-        if (!NetworkingManager.RegisterNetConfigInstance(cfg))
+        if (!NetworkingManager.RegisterNetConfigInstance(cfg, syncMode))
         {
             Utils.Logging.PrintError($"Network Registration for {cfg.ModName} {cfg.Name} failed.");
         }
@@ -696,35 +639,6 @@ public static partial class ConfigManager
 
     private static void RemoveConfigFromLists(IConfigBase config)
     {
-        if (config.MenuCategory != IConfigBase.Category.Ignore)
-        {
-            ConfigIndex? ci = Indexer_MenuCategory[config.MenuCategory].First(entry => 
-                entry.Name.Equals(config.Name) && entry.ModName.Equals(config.ModName));
-            // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
-            if (ci is not null)
-                Indexer_MenuCategory[config.MenuCategory].Remove(ci);
-        }
-        
-        if (config.NetSync != NetworkSync.NoSync)
-        {
-            ConfigIndex? ci = Indexer_NetSync[config.NetSync].First(entry => 
-                entry.Name.Equals(config.Name) && entry.ModName.Equals(config.ModName));
-            // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
-            if (ci is not null)
-                Indexer_NetSync[config.NetSync].Remove(ci);
-        }
-
-#if CLIENT
-        if (config is IConfigControl)
-        {
-            ConfigIndex? ci = Indexer_KeyMouseControls.First(entry =>
-                entry.Name.Equals(config.Name) && entry.ModName.Equals(config.ModName));
-            // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
-            if (ci is not null)
-                Indexer_KeyMouseControls.Remove(ci);
-        }
-#endif
-
         LoadedConfigEntries[config.ModName]?.Remove(config.Name);
 
         ConfigIndex? ci2 = null;
@@ -765,49 +679,6 @@ public static partial class ConfigManager
             return;
         }
         LoadedConfigEntries[config.ModName].Add(config.Name, config);
-        
-        if (config.NetSync != NetworkSync.NoSync)
-        {
-            if (!Indexer_NetSync.ContainsKey(config.NetSync))
-                Indexer_NetSync.Add(config.NetSync, new List<ConfigIndex>());
-            bool exists = false;
-            Indexer_NetSync[config.NetSync].ForEach(index =>
-            {
-                if (index.Name.Equals(config.Name) && index.ModName.Equals(config.ModName))
-                {
-                    exists = true;
-                }
-            });
-            if (exists)
-                Utils.Logging.PrintError($"ConfigManager::AddConfigToList() | Could not register the config entry from ModName {config.ModName} with the name {config.Name} for NETSYNC. An entry already exists!");
-            else
-                Indexer_NetSync[config.NetSync].Add(new ConfigIndex(config.ModName, config.Name));
-        }
-
-        if (config.MenuCategory != IConfigBase.Category.Ignore)
-        {
-            if (!Indexer_MenuCategory.ContainsKey(config.MenuCategory))
-                Indexer_MenuCategory.Add(config.MenuCategory, new List<ConfigIndex>());
-            bool exists = false;
-            Indexer_MenuCategory[config.MenuCategory].ForEach(index =>
-            {
-                if (index.Name.Equals(config.Name) && index.ModName.Equals(config.ModName))
-                {
-                    exists = true;
-                }
-            });
-            if (exists)
-                Utils.Logging.PrintError($"ConfigManager::AddConfigToList() | Could not register the config entry from ModName {config.ModName} with the name {config.Name} for DISPLAY. An entry already exists!");
-            else
-                Indexer_MenuCategory[config.MenuCategory].Add(new ConfigIndex(config.ModName, config.Name));
-        }
-
-#if CLIENT
-        if (config is IConfigControl)
-        {
-            Indexer_KeyMouseControls.Add(new ConfigIndex(config.ModName, config.Name));
-        }
-#endif
 
         ConfigIndex? ci = null;
         Indexer_AllLoadedEntries.ForEach(entry =>
@@ -831,9 +702,6 @@ public static partial class ConfigManager
     /// KeyMap: [ModName] -> [Name]
     /// </summary>
     private static readonly Dictionary<string, Dictionary<string, IConfigBase>> LoadedConfigEntries = new();
-    private static readonly Dictionary<IConfigBase.Category, List<ConfigIndex>> Indexer_MenuCategory = new();
-    private static readonly Dictionary<NetworkSync, List<ConfigIndex>> Indexer_NetSync = new();
-    private static readonly List<ConfigIndex> Indexer_KeyMouseControls = new();
     private static readonly List<ConfigIndex> Indexer_AllLoadedEntries = new();
     private static readonly Dictionary<string, string> LoadedXDocKeys = new();
 

--- a/ModdingToolkit/CSharp/Shared/Config/ConfigManager.cs
+++ b/ModdingToolkit/CSharp/Shared/Config/ConfigManager.cs
@@ -417,7 +417,16 @@ public static partial class ConfigManager
         LoadData(cfg, filePathOverride);
 #if CLIENT
         if (cfg is IDisplayable displayable && displayData is not null)
-            RegisterDisplayable(displayable, displayData);
+        {
+            RegisterDisplayable(displayable, displayData with
+            {
+                Name = cfg.Name, 
+                ModName = cfg.ModName, 
+                DisplayName = displayData.DisplayName.IsNullOrWhiteSpace() ? cfg.Name : displayData.DisplayName, 
+                DisplayModName = displayData.DisplayModName.IsNullOrWhiteSpace() ? cfg.ModName : displayData.DisplayModName,
+                DisplayCategory = displayData.DisplayCategory.IsNullOrWhiteSpace() ? "All" : displayData.DisplayCategory
+            });
+        }
 #endif
         if (cfg is INetConfigBase inc)
             RegisterForNetworking(inc, syncMode);

--- a/ModdingToolkit/CSharp/Shared/Config/ConfigManager.cs
+++ b/ModdingToolkit/CSharp/Shared/Config/ConfigManager.cs
@@ -59,7 +59,10 @@ public static partial class ConfigManager
         NetworkSync networkSync = NetworkSync.NoSync,
         Action<IConfigEntry<T>>? onValueChanged = null,
         Func<T, bool>? validateNewInput = null,
-        string? filePathOverride = null) where T : IConvertible
+        string? filePathOverride = null,
+        string? displayName = null,
+        string? displayModname = null,
+        string? displayCategory = null) where T : IConvertible
     {
         return CreateIConfigEntry(name, modName, defaultValue, menuCategory, networkSync, onValueChanged,
             validateNewInput, filePathOverride);
@@ -87,10 +90,14 @@ public static partial class ConfigManager
         IConfigBase.Category menuCategory = IConfigBase.Category.Gameplay,
         Func<string, bool>? valueChangePredicate = null,
         Action<IConfigList>? onValueChanged = null,
-        string? filePathOverride = null)
+        string? filePathOverride = null,
+        string? displayName = null,
+        string? displayModname = null,
+        string? displayCategory = null)
     {
         return CreateIConfigList(name, modName, defaultValue, valueList, networkSync, 
-            menuCategory, valueChangePredicate, onValueChanged, filePathOverride);
+            menuCategory, valueChangePredicate, onValueChanged, filePathOverride,
+            displayName, displayModname, displayCategory);
     }
 
     /// <summary>
@@ -116,10 +123,13 @@ public static partial class ConfigManager
         IConfigBase.Category menuCategory = IConfigBase.Category.Gameplay,
         Func<int, bool>? valueChangePredicate = null,
         Action<IConfigRangeInt>? onValueChanged = null,
-        string? filePathOverride = null)
+        string? filePathOverride = null,
+        string? displayName = null,
+        string? displayModname = null,
+        string? displayCategory = null)
     {
         return CreateIConfigRangeInt(name, modName, defaultValue, minValue, maxValue, steps, networkSync, menuCategory,
-            valueChangePredicate, onValueChanged, filePathOverride);
+            valueChangePredicate, onValueChanged, filePathOverride, displayName, displayModname, displayCategory);
     }
     
     /// <summary>
@@ -145,10 +155,13 @@ public static partial class ConfigManager
         IConfigBase.Category menuCategory = IConfigBase.Category.Gameplay,
         Func<float, bool>? valueChangePredicate = null,
         Action<IConfigRangeFloat>? onValueChanged = null,
-        string? filePathOverride = null)
+        string? filePathOverride = null,
+        string? displayName = null,
+        string? displayModname = null,
+        string? displayCategory = null)
     {
         return CreateIConfigRangeFloat(name, modName, defaultValue, minValue, maxValue, steps, networkSync, menuCategory,
-            valueChangePredicate, onValueChanged, filePathOverride);
+            valueChangePredicate, onValueChanged, filePathOverride, displayName, displayModname, displayCategory);
     }
 
     /// <summary>
@@ -339,11 +352,15 @@ public static partial class ConfigManager
         NetworkSync networkSync,
         Action<IConfigEntry<T>>? onValueChanged,
         Func<T, bool>? validateNewInput,
-        string? filePathOverride = null
+        string? filePathOverride = null,
+        string? displayName = null,
+        string? displayModname = null,
+        string? displayCategory = null
         ) where T : IConvertible
     {
         ConfigEntry<T> ce = new();
-        ce.Initialize(name, modName, defaultValue, defaultValue, networkSync, menuCategory, validateNewInput, onValueChanged);
+        ce.Initialize(name, modName, defaultValue, defaultValue, networkSync, menuCategory, validateNewInput, 
+            onValueChanged, displayName, displayModname, displayCategory);
         AddConfigToLists(ce);
         LoadData(ce, filePathOverride);
         if (ce is INetConfigBase ince)
@@ -357,10 +374,14 @@ public static partial class ConfigManager
         IConfigBase.Category menuCategory = IConfigBase.Category.Gameplay,
         Func<string, bool>? valueChangePredicate = null,
         Action<IConfigList>? onValueChanged = null,
-        string? filePathOverride = null)
+        string? filePathOverride = null,
+        string? displayName = null,
+        string? displayModname = null,
+        string? displayCategory = null)
     {
         ConfigList cl = new();
-        cl.Initialize(name, modName, defaultValue, defaultValue, valueList, sync, menuCategory, valueChangePredicate, onValueChanged);
+        cl.Initialize(name, modName, defaultValue, defaultValue, valueList, sync, menuCategory, valueChangePredicate, 
+            onValueChanged, displayName, displayModname, displayCategory);
         AddConfigToLists(cl);
         LoadData(cl, filePathOverride);
         if (cl is INetConfigBase ince)
@@ -375,10 +396,14 @@ public static partial class ConfigManager
         IConfigBase.Category menuCategory = IConfigBase.Category.Gameplay,
         Func<int, bool>? valueChangePredicate = null,
         Action<IConfigRangeInt>? onValueChanged = null,
-        string? filePathOverride = null)
+        string? filePathOverride = null,
+        string? displayName = null,
+        string? displayModname = null,
+        string? displayCategory = null)
     {
         ConfigRangeInt cr = new();
-        cr.Initialize(name, modName, defaultValue, defaultValue, minValue, maxValue, steps, sync, menuCategory, valueChangePredicate);
+        cr.Initialize(name, modName, defaultValue, defaultValue, minValue, maxValue, steps, sync, menuCategory, 
+            valueChangePredicate, onValueChanged, displayName, displayModname, displayCategory);
         AddConfigToLists(cr);
         LoadData(cr, filePathOverride);
         if (cr is INetConfigBase ince)
@@ -393,10 +418,14 @@ public static partial class ConfigManager
         IConfigBase.Category menuCategory = IConfigBase.Category.Gameplay,
         Func<float, bool>? valueChangePredicate = null,
         Action<IConfigRangeFloat>? onValueChanged = null,
-        string? filePathOverride = null)
+        string? filePathOverride = null,
+        string? displayName = null,
+        string? displayModname = null,
+        string? displayCategory = null)
     {
         ConfigRangeFloat cr = new();
-        cr.Initialize(name, modName, defaultValue, defaultValue, minValue, maxValue, steps, sync, menuCategory, valueChangePredicate);
+        cr.Initialize(name, modName, defaultValue, defaultValue, minValue, maxValue, steps, sync, menuCategory, 
+            valueChangePredicate, onValueChanged, displayName, displayModname, displayCategory);
         AddConfigToLists(cr);
         LoadData(cr, filePathOverride);
         if (cr is INetConfigBase ince)

--- a/ModdingToolkit/CSharp/Shared/Config/ConfigRangeFloat.cs
+++ b/ModdingToolkit/CSharp/Shared/Config/ConfigRangeFloat.cs
@@ -12,8 +12,8 @@ public class ConfigRangeFloat : ConfigEntry<float>, IConfigRangeFloat
 
 
     public void Initialize(string name, string modName, float newValue, float defaultValue, float minValue, float maxValue, int steps,
-        NetworkSync sync = NetworkSync.NoSync, IConfigBase.Category menuCategory = IConfigBase.Category.Gameplay,
-        Func<float, bool>? valueChangePredicate = null, Action<IConfigRangeFloat>? onValueChanged = null)
+        Func<float, bool>? valueChangePredicate = null, 
+        Action<IConfigRangeFloat>? onValueChanged = null)
     {
         if (minValue >= maxValue)
             throw new ArgumentException(
@@ -24,12 +24,11 @@ public class ConfigRangeFloat : ConfigEntry<float>, IConfigRangeFloat
         MaxValue = maxValue;
         _onValChanged = onValueChanged;
         
-        base.Initialize(name, modName, newValue, defaultValue, sync, menuCategory, valueChangePredicate, _ =>
+        base.Initialize(name, modName, newValue, defaultValue, valueChangePredicate, _ =>
         {
             _onValChanged?.Invoke(this);
         });
     }
 
     public override bool Validate(float value) => value >= MinValue && value <= MaxValue && base.Validate(value);
-    public override IConfigBase.DisplayType GetDisplayType() => IConfigBase.DisplayType.Slider;
 }

--- a/ModdingToolkit/CSharp/Shared/Config/ConfigRangeFloat.cs
+++ b/ModdingToolkit/CSharp/Shared/Config/ConfigRangeFloat.cs
@@ -13,7 +13,8 @@ public class ConfigRangeFloat : ConfigEntry<float>, IConfigRangeFloat
 
     public void Initialize(string name, string modName, float newValue, float defaultValue, float minValue, float maxValue, int steps,
         NetworkSync sync = NetworkSync.NoSync, IConfigBase.Category menuCategory = IConfigBase.Category.Gameplay,
-        Func<float, bool>? valueChangePredicate = null, Action<IConfigRangeFloat>? onValueChanged = null)
+        Func<float, bool>? valueChangePredicate = null, Action<IConfigRangeFloat>? onValueChanged = null,
+        string? displayName = null, string? displayModname = null, string? displayCategory = null)
     {
         if (minValue >= maxValue)
             throw new ArgumentException(
@@ -27,7 +28,7 @@ public class ConfigRangeFloat : ConfigEntry<float>, IConfigRangeFloat
         base.Initialize(name, modName, newValue, defaultValue, sync, menuCategory, valueChangePredicate, _ =>
         {
             _onValChanged?.Invoke(this);
-        });
+        }, displayName, displayModname, displayCategory);
     }
 
     public override bool Validate(float value) => value >= MinValue && value <= MaxValue && base.Validate(value);

--- a/ModdingToolkit/CSharp/Shared/Config/ConfigRangeFloat.cs
+++ b/ModdingToolkit/CSharp/Shared/Config/ConfigRangeFloat.cs
@@ -2,7 +2,7 @@ using ModdingToolkit.Networking;
 
 namespace ModdingToolkit.Config;
 
-public class ConfigRangeFloat : ConfigEntry<float>, IConfigRangeFloat
+public partial class ConfigRangeFloat : ConfigEntry<float>, IConfigRangeFloat
 {
     public float MinValue { get; private set; }
     public float MaxValue { get; private set; }

--- a/ModdingToolkit/CSharp/Shared/Config/ConfigRangeInt.cs
+++ b/ModdingToolkit/CSharp/Shared/Config/ConfigRangeInt.cs
@@ -13,7 +13,8 @@ public class ConfigRangeInt : ConfigEntry<int>, IConfigRangeInt
 
     public void Initialize(string name, string modName, int newValue, int defaultValue, int minValue, int maxValue, int steps,
         NetworkSync sync = NetworkSync.NoSync, IConfigBase.Category menuCategory = IConfigBase.Category.Gameplay,
-        Func<int, bool>? valueChangePredicate = null, Action<IConfigRangeInt>? onValueChanged = null)
+        Func<int, bool>? valueChangePredicate = null, Action<IConfigRangeInt>? onValueChanged = null,
+        string? displayName = null, string? displayModname = null, string? displayCategory = null)
     {
         if (minValue >= maxValue)
             throw new ArgumentException(
@@ -24,7 +25,7 @@ public class ConfigRangeInt : ConfigEntry<int>, IConfigRangeInt
         _onValChanged = onValueChanged;
         
         base.Initialize(name, modName, newValue, defaultValue, sync, menuCategory, 
-            valueChangePredicate, _ => _onValChanged?.Invoke(this));
+            valueChangePredicate, _ => _onValChanged?.Invoke(this), displayName, displayModname, displayCategory);
     }
 
     public override bool Validate(int value) => value >= MinValue && value <= MaxValue && base.Validate(value);

--- a/ModdingToolkit/CSharp/Shared/Config/ConfigRangeInt.cs
+++ b/ModdingToolkit/CSharp/Shared/Config/ConfigRangeInt.cs
@@ -12,8 +12,8 @@ public class ConfigRangeInt : ConfigEntry<int>, IConfigRangeInt
     private Action<IConfigRangeInt>? _onValChanged;
 
     public void Initialize(string name, string modName, int newValue, int defaultValue, int minValue, int maxValue, int steps,
-        NetworkSync sync = NetworkSync.NoSync, IConfigBase.Category menuCategory = IConfigBase.Category.Gameplay,
-        Func<int, bool>? valueChangePredicate = null, Action<IConfigRangeInt>? onValueChanged = null)
+        Func<int, bool>? valueChangePredicate = null, 
+        Action<IConfigRangeInt>? onValueChanged = null)
     {
         if (minValue >= maxValue)
             throw new ArgumentException(
@@ -23,10 +23,9 @@ public class ConfigRangeInt : ConfigEntry<int>, IConfigRangeInt
         MaxValue = maxValue;
         _onValChanged = onValueChanged;
         
-        base.Initialize(name, modName, newValue, defaultValue, sync, menuCategory, 
+        base.Initialize(name, modName, newValue, defaultValue,
             valueChangePredicate, _ => _onValChanged?.Invoke(this));
     }
 
     public override bool Validate(int value) => value >= MinValue && value <= MaxValue && base.Validate(value);
-    public override IConfigBase.DisplayType GetDisplayType() => IConfigBase.DisplayType.Slider;
 }

--- a/ModdingToolkit/CSharp/Shared/Config/ConfigRangeInt.cs
+++ b/ModdingToolkit/CSharp/Shared/Config/ConfigRangeInt.cs
@@ -2,7 +2,7 @@
 
 namespace ModdingToolkit.Config;
 
-public class ConfigRangeInt : ConfigEntry<int>, IConfigRangeInt
+public partial class ConfigRangeInt : ConfigEntry<int>, IConfigRangeInt
 {
     public int MinValue { get; private set; }
     public int MaxValue { get; private set; }

--- a/ModdingToolkit/CSharp/Shared/Config/ECategory.cs
+++ b/ModdingToolkit/CSharp/Shared/Config/ECategory.cs
@@ -1,0 +1,8 @@
+﻿namespace ModdingToolkit.Config;
+
+public enum Category
+{
+    Controls,
+    Gameplay, 
+    Ignore,    
+}

--- a/ModdingToolkit/CSharp/Shared/Config/EDisplayType.cs
+++ b/ModdingToolkit/CSharp/Shared/Config/EDisplayType.cs
@@ -1,0 +1,12 @@
+﻿namespace ModdingToolkit.Config;
+
+public enum DisplayType
+{
+    DropdownEnum,
+    DropdownList,
+    KeyOrMouse,
+    Number,
+    Slider,
+    Standard,
+    Tickbox
+}

--- a/ModdingToolkit/CSharp/Shared/Config/IConfigBase.cs
+++ b/ModdingToolkit/CSharp/Shared/Config/IConfigBase.cs
@@ -7,25 +7,9 @@ public interface IConfigBase
     string Name { get; }
     Type SubTypeDef { get; }
     string ModName { get; }
-    public Category MenuCategory { get; }
-    public NetworkSync NetSync { get; }
     string GetStringValue();
     string GetStringDefaultValue();
     void SetValueFromString(string value);
     void SetValueAsDefault();
-    DisplayType GetDisplayType();
     bool ValidateString(string value);
-    
-    public enum Category
-    {
-        Gameplay, 
-        Ignore,    
-        Audio_NOTIMPL,
-        Graphics_NOTIMPL
-    }
-
-    public enum DisplayType
-    {
-        DropdownEnum, DropdownList, KeyOrMouse, Number, Slider, Standard, Tickbox
-    }
 }

--- a/ModdingToolkit/CSharp/Shared/Config/IConfigBase.cs
+++ b/ModdingToolkit/CSharp/Shared/Config/IConfigBase.cs
@@ -4,12 +4,41 @@ namespace ModdingToolkit.Config;
 
 public interface IConfigBase
 {
+    /// <summary>
+    /// The name of the instance.
+    /// </summary>
     string Name { get; }
+    /// <summary>
+    /// If this type stores an internal value, then this should return that type.
+    /// </summary>
     Type SubTypeDef { get; }
+    /// <summary>
+    /// The mod name collection that this instance belongs to.
+    /// </summary>
     string ModName { get; }
+    /// <summary>
+    /// Get the string representation of the internal value. 
+    /// </summary>
+    /// <returns></returns>
     string GetStringValue();
+    /// <summary>
+    /// Gets the string representation of the default internal value.
+    /// </summary>
+    /// <returns></returns>
     string GetStringDefaultValue();
+    /// <summary>
+    /// Sets the internal value with the string equivalent.
+    /// </summary>
+    /// <param name="value"></param>
     void SetValueFromString(string value);
+    /// <summary>
+    /// Sets the internal value to default.
+    /// </summary>
     void SetValueAsDefault();
+    /// <summary>
+    /// Validates a string-equivalent of an internal value.
+    /// </summary>
+    /// <param name="value">The string-value to test.</param>
+    /// <returns>If the string is valid.</returns>
     bool ValidateString(string value);
 }

--- a/ModdingToolkit/CSharp/Shared/Config/IConfigBase.cs
+++ b/ModdingToolkit/CSharp/Shared/Config/IConfigBase.cs
@@ -5,8 +5,11 @@ namespace ModdingToolkit.Config;
 public interface IConfigBase
 {
     string Name { get; }
-    Type SubTypeDef { get; }
+    string DisplayName { get; }
     string ModName { get; }
+    string DisplayModName { get; }
+    string DisplayCategory { get; }
+    Type SubTypeDef { get; }
     public Category MenuCategory { get; }
     public NetworkSync NetSync { get; }
     string GetStringValue();

--- a/ModdingToolkit/CSharp/Shared/Config/IConfigEntry.cs
+++ b/ModdingToolkit/CSharp/Shared/Config/IConfigEntry.cs
@@ -7,9 +7,7 @@ public interface IConfigEntry<T> : IConfigBase where T : IConvertible
     public T Value { get; set; }
     public T DefaultValue { get; }
 
-    void Initialize(string name, string modName, T newValue, T defaultValue, 
-        NetworkSync sync = NetworkSync.NoSync, 
-        IConfigBase.Category menuCategory = IConfigBase.Category.Gameplay, 
+    void Initialize(string name, string modName, T newValue, T defaultValue,
         Func<T, bool>? valueChangePredicate = null,
         Action<IConfigEntry<T>>? onValueChanged = null);
     bool Validate(T value);

--- a/ModdingToolkit/CSharp/Shared/Config/IConfigEntry.cs
+++ b/ModdingToolkit/CSharp/Shared/Config/IConfigEntry.cs
@@ -11,7 +11,10 @@ public interface IConfigEntry<T> : IConfigBase where T : IConvertible
         NetworkSync sync = NetworkSync.NoSync, 
         IConfigBase.Category menuCategory = IConfigBase.Category.Gameplay, 
         Func<T, bool>? valueChangePredicate = null,
-        Action<IConfigEntry<T>>? onValueChanged = null);
+        Action<IConfigEntry<T>>? onValueChanged = null,
+        string? displayName = null,
+        string? displayModName = null,
+        string? displayCategory = null);
     bool Validate(T value);
 }
 

--- a/ModdingToolkit/CSharp/Shared/Config/IConfigEntry.cs
+++ b/ModdingToolkit/CSharp/Shared/Config/IConfigEntry.cs
@@ -9,10 +9,7 @@ public interface IConfigEntry<T> : IConfigBase where T : IConvertible
 
     void Initialize(string name, string modName, T newValue, T defaultValue,
         Func<T, bool>? valueChangePredicate = null,
-        Action<IConfigEntry<T>>? onValueChanged = null,
-        string? displayName = null,
-        string? displayModName = null,
-        string? displayCategory = null);
+        Action<IConfigEntry<T>>? onValueChanged = null);
     bool Validate(T value);
 }
 

--- a/ModdingToolkit/CSharp/Shared/Config/IConfigEntry.cs
+++ b/ModdingToolkit/CSharp/Shared/Config/IConfigEntry.cs
@@ -4,12 +4,31 @@ namespace ModdingToolkit.Config;
 
 public interface IConfigEntry<T> : IConfigBase where T : IConvertible
 {
+    /// <summary>
+    /// The internal value.
+    /// </summary>
     public T Value { get; set; }
+    /// <summary>
+    /// The default value. Used if none other set.
+    /// </summary>
     public T DefaultValue { get; }
-
+    /// <summary>
+    /// Initializes the type-behind. This is intended for use by the ConfigManager and should not be called by API consumers.
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="modName"></param>
+    /// <param name="newValue">The internal value.</param>
+    /// <param name="defaultValue">The default internal value.</param>
+    /// <param name="valueChangePredicate">Called before a new internal value is assigned. Will only assign a new internal value if this returns true.</param>
+    /// <param name="onValueChanged">Called after a new internal value is assigned.</param>
     void Initialize(string name, string modName, T newValue, T defaultValue,
         Func<T, bool>? valueChangePredicate = null,
         Action<IConfigEntry<T>>? onValueChanged = null);
+    /// <summary>
+    /// Checks if the value is valid. This function will invoke "valueChangePredicate". Native-type internal equivalent of ValidateString();
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
     bool Validate(T value);
 }
 

--- a/ModdingToolkit/CSharp/Shared/Config/IConfigList.cs
+++ b/ModdingToolkit/CSharp/Shared/Config/IConfigList.cs
@@ -7,9 +7,8 @@ public interface IConfigList : IConfigBase
     public string Value { get; set; }
     public string DefaultValue { get; }
     ref readonly ImmutableList<string> GetReadOnlyList();
-    void Initialize(string name, string modName, string newValue, string defaultValue, List<string> valueList, 
-        NetworkSync sync = NetworkSync.NoSync, 
-        IConfigBase.Category menuCategory = IConfigBase.Category.Gameplay, 
+    void Initialize(string name, string modName, string newValue, string defaultValue, 
+        List<string> valueList,
         Func<string, bool>? valueChangePredicate = null,
         Action<IConfigList>? onValueChanged = null);
     bool Validate(string value);

--- a/ModdingToolkit/CSharp/Shared/Config/IConfigList.cs
+++ b/ModdingToolkit/CSharp/Shared/Config/IConfigList.cs
@@ -10,10 +10,7 @@ public interface IConfigList : IConfigBase
     void Initialize(string name, string modName, string newValue, string defaultValue, 
         List<string> valueList,
         Func<string, bool>? valueChangePredicate = null,
-        Action<IConfigList>? onValueChanged = null,
-        string? displayName = null,
-        string? displayModName = null,
-        string? displayCategory = null);
+        Action<IConfigList>? onValueChanged = null);
     bool Validate(string value);
     public int GetDefaultValueIndex();
     public void SetValueFromIndex(int index);

--- a/ModdingToolkit/CSharp/Shared/Config/IConfigList.cs
+++ b/ModdingToolkit/CSharp/Shared/Config/IConfigList.cs
@@ -11,7 +11,10 @@ public interface IConfigList : IConfigBase
         NetworkSync sync = NetworkSync.NoSync, 
         IConfigBase.Category menuCategory = IConfigBase.Category.Gameplay, 
         Func<string, bool>? valueChangePredicate = null,
-        Action<IConfigList>? onValueChanged = null);
+        Action<IConfigList>? onValueChanged = null,
+        string? displayName = null,
+        string? displayModName = null,
+        string? displayCategory = null);
     bool Validate(string value);
     public int GetDefaultValueIndex();
     public void SetValueFromIndex(int index);

--- a/ModdingToolkit/CSharp/Shared/Config/IConfigRangeFloat.cs
+++ b/ModdingToolkit/CSharp/Shared/Config/IConfigRangeFloat.cs
@@ -9,8 +9,6 @@ public interface IConfigRangeFloat : IConfigEntry<float>
     public int Steps { get; }
 
     void Initialize(string name, string modName, float newValue, float defaultValue, float minValue, float maxValue, int steps,
-        NetworkSync sync = NetworkSync.NoSync, 
-        IConfigBase.Category menuCategory = IConfigBase.Category.Gameplay, 
         Func<float, bool>? valueChangePredicate = null,
         Action<IConfigRangeFloat>? onValueChanged = null);
 }

--- a/ModdingToolkit/CSharp/Shared/Config/IConfigRangeFloat.cs
+++ b/ModdingToolkit/CSharp/Shared/Config/IConfigRangeFloat.cs
@@ -12,5 +12,8 @@ public interface IConfigRangeFloat : IConfigEntry<float>
         NetworkSync sync = NetworkSync.NoSync, 
         IConfigBase.Category menuCategory = IConfigBase.Category.Gameplay, 
         Func<float, bool>? valueChangePredicate = null,
-        Action<IConfigRangeFloat>? onValueChanged = null);
+        Action<IConfigRangeFloat>? onValueChanged = null,
+        string? displayName = null,
+        string? displayModname = null,
+        string? displayCategory = null);
 }

--- a/ModdingToolkit/CSharp/Shared/Config/IConfigRangeFloat.cs
+++ b/ModdingToolkit/CSharp/Shared/Config/IConfigRangeFloat.cs
@@ -10,8 +10,5 @@ public interface IConfigRangeFloat : IConfigEntry<float>
 
     void Initialize(string name, string modName, float newValue, float defaultValue, float minValue, float maxValue, int steps,
         Func<float, bool>? valueChangePredicate = null,
-        Action<IConfigRangeFloat>? onValueChanged = null,
-        string? displayName = null,
-        string? displayModname = null,
-        string? displayCategory = null);
+        Action<IConfigRangeFloat>? onValueChanged = null);
 }

--- a/ModdingToolkit/CSharp/Shared/Config/IConfigRangeInt.cs
+++ b/ModdingToolkit/CSharp/Shared/Config/IConfigRangeInt.cs
@@ -12,5 +12,8 @@ public interface IConfigRangeInt : IConfigEntry<int>
         NetworkSync sync = NetworkSync.NoSync, 
         IConfigBase.Category menuCategory = IConfigBase.Category.Gameplay, 
         Func<int, bool>? valueChangePredicate = null,
-        Action<IConfigRangeInt>? onValueChanged = null);
+        Action<IConfigRangeInt>? onValueChanged = null,
+        string? displayName = null,
+        string? displayModname = null,
+        string? displayCategory = null);
 }

--- a/ModdingToolkit/CSharp/Shared/Config/IConfigRangeInt.cs
+++ b/ModdingToolkit/CSharp/Shared/Config/IConfigRangeInt.cs
@@ -10,8 +10,5 @@ public interface IConfigRangeInt : IConfigEntry<int>
     
     void Initialize(string name, string modName, int newValue, int defaultValue, int minValue, int maxValue, int steps,
         Func<int, bool>? valueChangePredicate = null,
-        Action<IConfigRangeInt>? onValueChanged = null,
-        string? displayName = null,
-        string? displayModname = null,
-        string? displayCategory = null);
+        Action<IConfigRangeInt>? onValueChanged = null);
 }

--- a/ModdingToolkit/CSharp/Shared/Config/IConfigRangeInt.cs
+++ b/ModdingToolkit/CSharp/Shared/Config/IConfigRangeInt.cs
@@ -9,8 +9,6 @@ public interface IConfigRangeInt : IConfigEntry<int>
     public int Steps { get; }
     
     void Initialize(string name, string modName, int newValue, int defaultValue, int minValue, int maxValue, int steps,
-        NetworkSync sync = NetworkSync.NoSync, 
-        IConfigBase.Category menuCategory = IConfigBase.Category.Gameplay, 
         Func<int, bool>? valueChangePredicate = null,
         Action<IConfigRangeInt>? onValueChanged = null);
 }

--- a/ModdingToolkit/CSharp/Shared/Config/RDisplayData.cs
+++ b/ModdingToolkit/CSharp/Shared/Config/RDisplayData.cs
@@ -1,0 +1,19 @@
+﻿namespace ModdingToolkit.Config;
+
+/***
+ * Keep this in Shared to allow common typedef between the Client and Server.
+ */
+
+/// <summary>
+/// 
+/// </summary>
+/// <param name="Name"></param>
+/// <param name="ModName"></param>
+/// <param name="DisplayName"></param>
+/// <param name="DisplayModName"></param>
+/// <param name="DisplayCategory"></param>
+/// <param name="Tooltip"></param>
+/// <param name="ImageIcon"></param>
+/// <param name="MenuCategory"></param>
+public record DisplayData(string? Name, string? ModName, string? DisplayName, string? DisplayModName, 
+    string? DisplayCategory, string? Tooltip, string? ImageIcon, Category MenuCategory);

--- a/ModdingToolkit/CSharp/Shared/Config/RDisplayData.cs
+++ b/ModdingToolkit/CSharp/Shared/Config/RDisplayData.cs
@@ -1,19 +1,19 @@
 ﻿namespace ModdingToolkit.Config;
 
 /***
- * Keep this in Shared to allow common typedef between the Client and Server.
+ * Keep this in Shared to allow common typedef and method sig between the Client and Server.
  */
 
 /// <summary>
-/// 
+/// Contains the Display Data for use with Menus. Used by IDisplayable. 
 /// </summary>
-/// <param name="Name"></param>
-/// <param name="ModName"></param>
-/// <param name="DisplayName"></param>
-/// <param name="DisplayModName"></param>
-/// <param name="DisplayCategory"></param>
-/// <param name="Tooltip"></param>
-/// <param name="ImageIcon"></param>
-/// <param name="MenuCategory"></param>
-public record DisplayData(string? Name, string? ModName, string? DisplayName, string? DisplayModName, 
-    string? DisplayCategory, string? Tooltip, string? ImageIcon, Category MenuCategory);
+/// <param name="Name">Internal name of the instance.</param>
+/// <param name="ModName">Internal mod name of the instance.</param>
+/// <param name="DisplayName">The name to display in GUIs and Menus.</param>
+/// <param name="DisplayModName">The mod name to display in GUIs and Menus.</param>
+/// <param name="DisplayCategory">Category this instance falls under. Used by menus when filtering by category.</param>
+/// <param name="Tooltip">The tooltip shown on hover.</param>
+/// <param name="ImageIcon">The image icon to be used by GUIs when referring to this instance.</param>
+/// <param name="MenuCategory">The category/section that this will appear in the SettingsMenu.</param>
+public record DisplayData(string? Name = null, string? ModName = null, string? DisplayName = null, string? DisplayModName = null, 
+    string? DisplayCategory = null, string? Tooltip = null, string? ImageIcon = null, Category MenuCategory = Category.Gameplay);

--- a/ModdingToolkit/CSharp/Shared/MemoryCallbackCache.cs
+++ b/ModdingToolkit/CSharp/Shared/MemoryCallbackCache.cs
@@ -2,8 +2,7 @@
 
 public static class MemoryCallbackCache
 {
-    private static Dictionary<Guid, CallbackMachine> CallbackMachines = new();
-
+    private static readonly Dictionary<Guid, CallbackMachine> CallbackMachines = new();
 
     public static Guid CreateInstance()
     {

--- a/ModdingToolkit/CSharp/Shared/MemoryCallbackCache.cs
+++ b/ModdingToolkit/CSharp/Shared/MemoryCallbackCache.cs
@@ -1,0 +1,145 @@
+﻿namespace ModdingToolkit;
+
+public static class MemoryCallbackCache
+{
+    private static Dictionary<Guid, CallbackMachine> CallbackMachines = new();
+
+
+    public static Guid CreateInstance()
+    {
+        Guid id = Guid.NewGuid();
+        CallbackMachines.Add(id, new CallbackMachine(id));
+        return id;
+    }
+
+    public static bool DisposeInstance(Guid instanceId)
+    {
+        if (!CallbackMachines.ContainsKey(instanceId))
+            return false;
+        CallbackMachines[instanceId].RemoveAll();
+        CallbackMachines.Remove(instanceId);
+        return true;
+    }
+    
+    public static Guid AddCallback<T1, T2>(Guid id, T1 target, T2 value, Action<WeakReference<T1>, T2> callback) 
+        where T1 : class where T2 : IConvertible
+    {
+        if (!CallbackMachines.ContainsKey(id))
+            return Guid.Empty;
+        return CallbackMachines[id].RegisterNewCallback(new WeakReference<T1>(target), value, callback);
+    }
+
+    public static bool Invoke(Guid instanceId, Guid callbackId)
+    {
+        if (!CallbackMachines.ContainsKey(instanceId))
+            return false;
+        return CallbackMachines[instanceId].ExecuteCallback(callbackId);
+    }
+
+    public static bool Remove(Guid instanceId, Guid callbackId)
+    {
+        if (!CallbackMachines.ContainsKey(instanceId))
+            return false;
+        return CallbackMachines[instanceId].RemoveCallback(callbackId);
+    }
+
+    public static bool ExecuteAndRemove(Guid instanceId, Guid callbackId)
+    {
+        if (!CallbackMachines.ContainsKey(instanceId))
+            return false;
+        if (CallbackMachines[instanceId].ExecuteCallback(callbackId))
+            return CallbackMachines[instanceId].RemoveCallback(callbackId);
+        return false;
+    }
+
+    public static bool ExecuteAll(Guid instanceId)
+    {
+        if (!CallbackMachines.ContainsKey(instanceId))
+            return false;
+        CallbackMachines[instanceId].ExecuteAll();
+        return true;
+    }
+
+    public static bool RemoveAll(Guid instanceId)
+    {
+        if (!CallbackMachines.ContainsKey(instanceId))
+            return false;
+        CallbackMachines[instanceId].RemoveAll();
+        return true;
+    }
+
+    public static bool ExecuteAndRemoveAll(Guid instanceId)
+    {
+        if (ExecuteAll(instanceId))
+            return RemoveAll(instanceId);
+        return false;
+    }
+
+
+    private class CallbackMachine
+    {
+        public readonly Guid Id;
+        public readonly Dictionary<Guid, CallbackRef> Callbacks;
+        
+        public CallbackMachine(Guid id)
+        {
+            this.Id = id;
+            this.Callbacks = new();
+        }
+
+        public Guid RegisterNewCallback<T1, T2>(WeakReference<T1> target, T2 value,
+            Action<WeakReference<T1>, T2> callback) where T1 : class where T2 : IConvertible
+        {
+            Guid callbackId = Guid.NewGuid();
+            CacheStore<T1,T2>.CallbackStores.Add(
+                callbackId, 
+                new CacheStore<T1, T2>.CallbackStore(target, value, callback));
+            this.Callbacks.Add(callbackId, new CallbackRef(
+                () => 
+                {
+                    var c = CacheStore<T1, T2>.CallbackStores[callbackId];
+                    c.Callback?.Invoke(c.Target, c.Value);
+                },
+                () => CacheStore<T1, T2>.CallbackStores.Remove(callbackId)));
+            return callbackId;
+        }
+
+        public bool ExecuteCallback(Guid callbackId)
+        {
+            if (!this.Callbacks.ContainsKey(callbackId))
+                return false;
+            this.Callbacks[callbackId].Execute?.Invoke();
+            return true;
+        }
+
+        public bool RemoveCallback(Guid callbackId)
+        {
+            if (!this.Callbacks.ContainsKey(callbackId))
+                return false;
+            this.Callbacks[callbackId].Remove?.Invoke();
+            this.Callbacks.Remove(callbackId);
+            return true;
+        }
+
+        public void ExecuteAll()
+        {
+            foreach (var pair in Callbacks)
+                pair.Value.Execute?.Invoke();
+        }
+
+        public void RemoveAll()
+        {
+            foreach (var pair in Callbacks)
+                pair.Value.Remove?.Invoke();
+            Callbacks.Clear();
+        }
+
+        public record CallbackRef(Action Execute, Action Remove);
+    }
+
+    private static class CacheStore<T1, T2> where T1 : class where T2 : IConvertible
+    {
+        public static readonly Dictionary<Guid, CallbackStore> CallbackStores = new();
+        public record CallbackStore(WeakReference<T1> Target, T2 Value, Action<WeakReference<T1>, T2> Callback);
+    }
+}

--- a/ModdingToolkit/CSharp/Shared/Networking/ENetworkSync.cs
+++ b/ModdingToolkit/CSharp/Shared/Networking/ENetworkSync.cs
@@ -7,7 +7,7 @@ public enum NetworkSync
     /// </summary>
     NoSync, 
     /// <summary>
-    /// Only the server can make changes.
+    /// Only the server or clients with Server Authority can make changes.
     /// </summary>
     ServerAuthority, 
     /// <summary>

--- a/ModdingToolkit/CSharp/Shared/Networking/INetConfigBase.cs
+++ b/ModdingToolkit/CSharp/Shared/Networking/INetConfigBase.cs
@@ -21,4 +21,5 @@ public interface INetConfigBase
     internal void SubscribeToNetEvents(System.Action<INetConfigBase> evtHandle);
     internal void UnsubscribeFromNetEvents(System.Action<INetConfigBase> evtHandle);
     void TriggerNetEvent();
+    void InitializeNetworking(Guid netId, NetworkSync networkSync);
 }

--- a/ModdingToolkit/CSharp/Shared/Networking/INetVar.cs
+++ b/ModdingToolkit/CSharp/Shared/Networking/INetVar.cs
@@ -1,0 +1,8 @@
+﻿namespace ModdingToolkit.Networking;
+
+public interface INetVar<T> : INetConfigBase where T : IConvertible
+{
+    public T Value { get; set; }
+
+    public void Initialize(string modName, string name, T value);
+}

--- a/ModdingToolkit/CSharp/Shared/Networking/NetVar.cs
+++ b/ModdingToolkit/CSharp/Shared/Networking/NetVar.cs
@@ -1,0 +1,84 @@
+﻿using Barotrauma.Networking;
+
+namespace ModdingToolkit.Networking;
+
+public sealed partial class NetVar<T> : INetVar<T> where T : IConvertible
+{
+    private System.Action<INetConfigBase>? _onNetworkEvent;
+    
+    public Guid NetId { get; private set; }
+    public string ModName { get; private set; }
+    public string Name { get; private set; }
+    
+    public Type NetSyncVarTypeDef => typeof(T);
+    
+    public void SetNetworkingId(Guid id) => this.NetId = id;
+
+    public NetworkSync NetSync { get; private set; }
+
+    private T _value;
+
+    public T Value
+    {
+        get => this._value;
+        set
+        {
+            if (NetAuthorityValidate())
+            {
+                this._value = value;
+                this.TriggerNetEvent();
+            }
+        }
+    }
+    
+    bool INetConfigBase.WriteNetworkValue(IWriteMessage msg)
+    {
+#if SERVER
+        if (NetSync is NetworkSync.NoSync)
+            return false;
+#else
+        if (NetSync is NetworkSync.ServerAuthority or NetworkSync.ClientPermissiveDesync or NetworkSync.NoSync)
+            return false;
+#endif
+        Utils.Networking.WriteNetValueFromType(msg, this.Value);
+        return true;
+    }
+
+    bool INetConfigBase.ReadNetworkValue(IReadMessage msg)
+    {
+#if SERVER
+        if (NetSync is NetworkSync.ServerAuthority or NetworkSync.ClientPermissiveDesync or NetworkSync.NoSync)
+            return false;
+#else
+        if (NetSync is NetworkSync.NoSync)
+            return false;
+#endif
+        try
+        {
+            this._value = Utils.Networking.ReadNetValueFromType<T>(msg);
+            return true;
+        }
+        catch (Exception e)
+        {
+            Utils.Logging.PrintError($"NetVar::ReadNetworkValue() | Bad read. ModName={this.ModName}, Name={this.Name}");
+            return false;
+        }
+    }
+
+    void INetConfigBase.SubscribeToNetEvents(Action<INetConfigBase> evtHandle) => this._onNetworkEvent += evtHandle;
+
+    void INetConfigBase.UnsubscribeFromNetEvents(Action<INetConfigBase> evtHandle) => this._onNetworkEvent -= evtHandle;
+
+    public void InitializeNetworking(Guid netId, NetworkSync networkSync)
+    {
+        this.NetSync = networkSync;
+        this.NetId = netId;
+    }
+    
+    public void Initialize(string modName, string name, T value)
+    {
+        this.ModName = modName;
+        this.Name = name;
+        this._value = value;
+    }
+}

--- a/ModdingToolkit/CSharp/Shared/Networking/NetVar.cs
+++ b/ModdingToolkit/CSharp/Shared/Networking/NetVar.cs
@@ -33,26 +33,12 @@ public sealed partial class NetVar<T> : INetVar<T> where T : IConvertible
     
     bool INetConfigBase.WriteNetworkValue(IWriteMessage msg)
     {
-#if SERVER
-        if (NetSync is NetworkSync.NoSync)
-            return false;
-#else
-        if (NetSync is NetworkSync.ServerAuthority or NetworkSync.ClientPermissiveDesync or NetworkSync.NoSync)
-            return false;
-#endif
         Utils.Networking.WriteNetValueFromType(msg, this.Value);
         return true;
     }
 
     bool INetConfigBase.ReadNetworkValue(IReadMessage msg)
     {
-#if SERVER
-        if (NetSync is NetworkSync.ServerAuthority or NetworkSync.ClientPermissiveDesync or NetworkSync.NoSync)
-            return false;
-#else
-        if (NetSync is NetworkSync.NoSync)
-            return false;
-#endif
         try
         {
             this._value = Utils.Networking.ReadNetValueFromType<T>(msg);

--- a/ModdingToolkit/CSharp/Shared/Networking/NetworkingManager.cs
+++ b/ModdingToolkit/CSharp/Shared/Networking/NetworkingManager.cs
@@ -112,10 +112,10 @@ public static partial class NetworkingManager
         IsInitialized = false;
     }
 
-    public static bool RegisterNetConfigInstance(INetConfigBase config)
+    public static bool RegisterNetConfigInstance(INetConfigBase config, NetworkSync syncMode)
     {
         Guid id = Guid.NewGuid();
-        if (!RegisterLocalConfig(config, id))
+        if (!RegisterLocalConfig(config, id, syncMode))
         {
             Utils.Logging.PrintError($"NetworkingManager::RegisterNetConfigInstance() | A config with that Guid exists locally. Unable to continue. Modname={config.ModName}, Name={config.Name}");
             return false;
@@ -148,11 +148,11 @@ public static partial class NetworkingManager
         return msg;
     }
 
-    private static bool RegisterLocalConfig(INetConfigBase cfg, Guid localId)
+    private static bool RegisterLocalConfig(INetConfigBase cfg, Guid localId, NetworkSync syncMode)
     {
         if (NetConfigRegistry.ContainsKey(localId) && NetConfigRegistry[localId] is not null)
             return false;
-        cfg.SetNetworkingId(localId);
+        cfg.InitializeNetworking(localId, syncMode);
         NetConfigRegistry[localId] = cfg;
         if (!Indexer_LocalGuidsLookup.ContainsKey(cfg.ModName))
             Indexer_LocalGuidsLookup.Add(cfg.ModName, new Dictionary<string, Guid>());

--- a/ModdingToolkit/CSharp/Shared/Utils.cs
+++ b/ModdingToolkit/CSharp/Shared/Utils.cs
@@ -216,6 +216,8 @@ public static class Utils
     
     #endregion
 
+    #region NETWORKING
+
     internal static class Networking
     {
         #region MESSAGE_UTILS
@@ -483,4 +485,23 @@ public static class Utils
 
         #endregion
     }
+
+    #endregion
+
+    #region GAME
+
+    public static class Game
+    {
+        public static bool IsRoundInProgress()
+        {
+#if CLIENT
+            if (Screen.Selected is not null
+                && Screen.Selected.IsEditor)
+                return false;
+#endif
+            return GameMain.GameSession is not null && Level.Loaded is not null;
+        }
+    }
+
+    #endregion
 }

--- a/ModdingToolkit/CSharp/Shared/Utils.cs
+++ b/ModdingToolkit/CSharp/Shared/Utils.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using Barotrauma.Items.Components;
 using Barotrauma.Networking;
 using ModdingToolkit.Networking;
 
@@ -6,6 +7,8 @@ namespace ModdingToolkit;
 
 public static class Utils
 {
+    #region LOGGING
+
     public static class Logging
     {
         public static void PrintMessage(string s)
@@ -26,7 +29,11 @@ public static class Utils
 #endif
         }
     }
+
+    #endregion
     
+    #region FILE_IO
+
     public static class IO
     {
         public static string PrepareFilePathString(string filePath) =>
@@ -206,9 +213,13 @@ public static class Utils
             Success, FilePathNull, FilePathInvalid, EntryMissing, DirectoryMissing, PathTooLong, InvalidOperation, IOFailure, UnknownError
         }
     }
+    
+    #endregion
 
     internal static class Networking
     {
+        #region MESSAGE_UTILS
+
         public static object ReadNetValueFromType(IReadMessage msg, Type type)
         {
             if (type == typeof(bool)) return msg.ReadBoolean();
@@ -241,13 +252,13 @@ public static class Utils
                 }
                 catch (Exception e)
                 {
-                    Utils.Logging.PrintError($"Utils.Net...::ReadNetValueFromType() | {e.Message}");
+                    Logging.PrintError($"Utils.Net...::ReadNetValueFromType() | {e.Message}");
                     return 0;
                 }
             }
 
-            Utils.Logging.PrintError(
-            $"Utils::ReadNetValueFromType() | The Type of {type.Name} is unsupported by Barotrauma Networking!");
+            Logging.PrintError(
+                $"Utils::ReadNetValueFromType() | The Type of {type.Name} is unsupported by Barotrauma Networking!");
             return 0;
         }
         
@@ -285,12 +296,12 @@ public static class Utils
                 }
                 catch (Exception e)
                 {
-                    Utils.Logging.PrintError($"Utils.Net...::ReadNetValueFromType<{typeof(T)}>() | {e.Message}");
+                    Logging.PrintError($"Utils.Net...::ReadNetValueFromType<{typeof(T)}>() | {e.Message}");
                     return default!;
                 }
             }
 
-            Utils.Logging.PrintError(
+            Logging.PrintError(
                 $"Utils::ReadNetValueFromType() | The Type of {type.Name} is unsupported by Barotrauma Networking!");
             return default!;
         }
@@ -306,7 +317,7 @@ public static class Utils
             // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
             if (value is null)
             {
-                Utils.Logging.PrintError(
+                Logging.PrintError(
                     $"Utils::WriteNetValueFromType() | The value was null for the type of {type.Name}.");
                 return;
             }
@@ -391,7 +402,7 @@ public static class Utils
             }
             else
             {
-                Utils.Logging.PrintError(
+                Logging.PrintError(
                     $"Utils::WriteNetValueFromType() | The Type of {type.Name} is unsupported by Barotrauma Networking!");
             }
         }
@@ -405,5 +416,71 @@ public static class Utils
         {
             Byte = 0, Short, Int, Long, String
         }
+
+        #endregion
+
+        #region NETMGR_UTILS
+
+        public static INetVar<T> CreateNetVar<T>(ItemComponent component, string className, string varName, T value, 
+            NetworkSync syncMode) where T : IConvertible
+        {
+            NetVar<T> netVar = new NetVar<T>();
+
+            int index = 0;
+            for (int i = 0; i < component.Item.Components.Count; i++)
+            {
+                if (component.Item.Components[i] == component)
+                {
+                    index = i;
+                    break;
+                }
+            }
+            netVar.Initialize($"{className}_{component.Item.ID}_{index}", varName, value);
+
+            if (!GameMain.IsMultiplayer || syncMode is NetworkSync.NoSync)
+                return netVar;
+
+            NetworkingManager.RegisterNetConfigInstance(netVar, syncMode);
+
+            return netVar;
+        }
+        
+        public static INetVar<T> CreateNetVar<T>(Item item, string className, string varName, T value, 
+            NetworkSync syncMode) where T : IConvertible
+        {
+            NetVar<T> netVar = new NetVar<T>();
+            
+            netVar.Initialize($"{className}_{item.ID}_NoCompID", varName, value);
+
+            if (!GameMain.IsMultiplayer || syncMode is NetworkSync.NoSync)
+                return netVar;
+
+            NetworkingManager.RegisterNetConfigInstance(netVar, syncMode);
+
+            return netVar;
+        }
+        
+        public static INetVar<T> CreateNetVar<T>(string baseName, string varName, T value, 
+            NetworkSync syncMode) where T : IConvertible
+        {
+            NetVar<T> netVar = new NetVar<T>();
+
+            int indexV = 0;
+            foreach (char c in baseName)
+            {
+                indexV += Convert.ToInt32(c);
+            }
+            
+            netVar.Initialize($"{baseName}_CID{indexV}", varName, value);
+
+            if (!GameMain.IsMultiplayer || syncMode is NetworkSync.NoSync)
+                return netVar;
+
+            NetworkingManager.RegisterNetConfigInstance(netVar, syncMode);
+
+            return netVar;
+        }
+
+        #endregion
     }
 }

--- a/ModdingToolkit/filelist.xml
+++ b/ModdingToolkit/filelist.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<contentpackage name="Modding Toolkit" modversion="0.0.1.3" corepackage="false">
+<contentpackage name="Modding Toolkit" modversion="0.0.2.0" corepackage="false">
     <Other file="%ModDir%/CSharp/Shared/Bootloader.cs" />
 </contentpackage>

--- a/ModdingToolkitClientTestPlugin/Bootloader.cs
+++ b/ModdingToolkitClientTestPlugin/Bootloader.cs
@@ -33,7 +33,7 @@ public class Bootloader : IAssemblyPlugin
             "TestEntry00",
             "ModdingTK",
             20.0f,
-            validateNewInput: f =>
+            valueChangePredicate: f =>
             {
                 if (Utils.Game.IsRoundInProgress())
                 {
@@ -98,11 +98,9 @@ public class Bootloader : IAssemblyPlugin
             "ModdingTK2",
             10f,
             NetworkSync.ServerAuthority,
-            (ce) =>
+            onValueChanged: (ce) =>
             {
-                PrintNetTestMsg(
-                    ce.ModName + ":" + ce.Name,
-                    ce.Value.ToString(CultureInfo.CurrentCulture));
+                PrintNetTestMsg(ce.ModName + ":" + ce.Name, ce.Value.ToString(CultureInfo.CurrentCulture));
             }
         );
         
@@ -111,7 +109,7 @@ public class Bootloader : IAssemblyPlugin
             "ModdingTK2",
             "Hello",
             NetworkSync.TwoWaySync,
-            (ce) =>
+            onValueChanged: (ce) =>
             {
                 PrintNetTestMsg(ce.ModName + ":" + ce.Name, ce.Value);
             }
@@ -124,7 +122,7 @@ public class Bootloader : IAssemblyPlugin
             new List<string> { "01", "02", "03", "04", "05" },
             NetworkSync.TwoWaySync,
             null,
-            (ce) =>
+            onValueChanged: (ce) =>
             {
                 PrintNetTestMsg(ce.ModName + ":" + ce.Name, ce.Value);
             }
@@ -138,9 +136,7 @@ public class Bootloader : IAssemblyPlugin
     private static void PrintNetTestMsg(string name, string value)
     {
         string mode = GameMain.IsSingleplayer ? "sp" : "mp";
-        Utils.Logging.PrintMessage(NetworkingManager.IsClient
-            ? $"net_ce_test: client, name: {name}, mode: {mode}, net_auth: srvauth, value {value}"
-            : $"net_ce_test: server, name: {name}, mode: {mode}, net_auth: srvauth, value {value}");
+        Utils.Logging.PrintMessage($"net_ce_test: name: {name}, mode: {mode}, net_auth: srvauth, value {value}");
     }
 
     #endregion

--- a/ModdingToolkitClientTestPlugin/Bootloader.cs
+++ b/ModdingToolkitClientTestPlugin/Bootloader.cs
@@ -32,38 +32,47 @@ public class Bootloader : IAssemblyPlugin
         ce_float = ConfigManager.AddConfigEntry(
             "TestEntry00",
             "ModdingTK",
-            20.0f
+            20.0f,
+            displayData: new DisplayData(DisplayName: "Test Entry 00", DisplayModName: "Modding TK", DisplayCategory: "Category 0") 
         );
         
         ce_int = ConfigManager.AddConfigEntry(
             "TestEntry01",
             "ModdingTK",
-            20
+            20,
+            displayData: new DisplayData(DisplayName: "Test Entry 01", DisplayModName: "Modding TK", DisplayCategory: "Category 0")
         );
         
         ce_string = ConfigManager.AddConfigEntry(
             "TestEntry02",
             "ModdingTK",
-            "MyValue"
+            "MyValue",
+            displayData: new DisplayData(DisplayName: "Test Entry 02", DisplayModName: "Modding TK", DisplayCategory: "Category 1")
         );
 
         cl = ConfigManager.AddConfigList(
             "TestEntry03",
             "ModdingTK",
             "03",
-            new List<string> { "01", "02", "03", "04", "05" }
+            new List<string> { "01", "02", "03", "04", "05" },
+            displayData: new DisplayData()
         );
 
         icri = ConfigManager.AddConfigRangeInt(
             "TestEntry04",
             "ModdingTK",
-            10, 0, 20, 21
+            10, 0, 20, 21,
+            displayData: new DisplayData()
         );
 
         icrf = ConfigManager.AddConfigRangeFloat(
             "TestEntry05",
             "ModdingTK",
-            10f, 0f, 100f, 101
+            10f, 0f, 100f, 101,
+            displayData: new DisplayData(
+                DisplayName: "Test Entry 05",
+                DisplayCategory: "Category 1"
+                )
         );
 
         ConfigManager.AddConfigBoolean(
@@ -79,7 +88,6 @@ public class Bootloader : IAssemblyPlugin
             "net_ce_test01",
             "ModdingTK2",
             10f,
-            IConfigBase.Category.Ignore,
             NetworkSync.ServerAuthority,
             (ce) =>
             {
@@ -93,7 +101,6 @@ public class Bootloader : IAssemblyPlugin
             "net_ce_test02",
             "ModdingTK2",
             "Hello",
-            IConfigBase.Category.Ignore,
             NetworkSync.TwoWaySync,
             (ce) =>
             {
@@ -107,7 +114,6 @@ public class Bootloader : IAssemblyPlugin
             "03",
             new List<string> { "01", "02", "03", "04", "05" },
             NetworkSync.TwoWaySync,
-            IConfigBase.Category.Ignore,
             null,
             (ce) =>
             {

--- a/ModdingToolkitClientTestPlugin/Bootloader.cs
+++ b/ModdingToolkitClientTestPlugin/Bootloader.cs
@@ -33,6 +33,15 @@ public class Bootloader : IAssemblyPlugin
             "TestEntry00",
             "ModdingTK",
             20.0f,
+            validateNewInput: f =>
+            {
+                if (Utils.Game.IsRoundInProgress())
+                {
+                    Utils.Logging.PrintMessage($"Round in progress, cannot change value.");
+                    return false;
+                }
+                return true;
+            },
             displayData: new DisplayData(DisplayName: "Test Entry 00", DisplayModName: "Modding TK", DisplayCategory: "Category 0") 
         );
         

--- a/ModdingToolkitServerTestPlugin/Bootloader.cs
+++ b/ModdingToolkitServerTestPlugin/Bootloader.cs
@@ -73,7 +73,6 @@ public class Bootloader : IAssemblyPlugin
             "net_ce_test01",
             "ModdingTK2",
             10f,
-            IConfigBase.Category.Ignore,
             NetworkSync.ServerAuthority,
             (ce) =>
             {
@@ -87,7 +86,6 @@ public class Bootloader : IAssemblyPlugin
             "net_ce_test02",
             "ModdingTK2",
             "Hello",
-            IConfigBase.Category.Ignore,
             NetworkSync.TwoWaySync,
             (ce) =>
             {
@@ -101,7 +99,6 @@ public class Bootloader : IAssemblyPlugin
             "03",
             new List<string> { "01", "02", "03", "04", "05" },
             NetworkSync.TwoWaySync,
-            IConfigBase.Category.Ignore,
             null,
             (ce) =>
             {

--- a/ModdingToolkitServerTestPlugin/Bootloader.cs
+++ b/ModdingToolkitServerTestPlugin/Bootloader.cs
@@ -27,7 +27,7 @@ public class Bootloader : IAssemblyPlugin
             "TestEntry00",
             "ModdingTK",
             20.0f,
-            validateNewInput: f =>
+            valueChangePredicate: f =>
             {
                 if (Utils.Game.IsRoundInProgress())
                 {
@@ -35,7 +35,8 @@ public class Bootloader : IAssemblyPlugin
                     return false;
                 }
                 return true;
-            }
+            },
+            displayData: new DisplayData(DisplayName: "Test Entry 00", DisplayModName: "Modding TK", DisplayCategory: "Category 0") 
         );
         
         ce_int = ConfigManager.AddConfigEntry(
@@ -83,11 +84,9 @@ public class Bootloader : IAssemblyPlugin
             "ModdingTK2",
             10f,
             NetworkSync.ServerAuthority,
-            (ce) =>
+            onValueChanged: (ce) =>
             {
-                PrintNetTestMsg(
-                    ce.ModName + ":" + ce.Name,
-                    ce.Value.ToString(CultureInfo.CurrentCulture));
+                PrintNetTestMsg(ce.ModName + ":" + ce.Name, ce.Value.ToString(CultureInfo.CurrentCulture));
             }
         );
         
@@ -96,7 +95,7 @@ public class Bootloader : IAssemblyPlugin
             "ModdingTK2",
             "Hello",
             NetworkSync.TwoWaySync,
-            (ce) =>
+            onValueChanged: (ce) =>
             {
                 PrintNetTestMsg(ce.ModName + ":" + ce.Name, ce.Value);
             }
@@ -109,7 +108,7 @@ public class Bootloader : IAssemblyPlugin
             new List<string> { "01", "02", "03", "04", "05" },
             NetworkSync.TwoWaySync,
             null,
-            (ce) =>
+            onValueChanged: (ce) =>
             {
                 PrintNetTestMsg(ce.ModName + ":" + ce.Name, ce.Value);
             }

--- a/ModdingToolkitServerTestPlugin/Bootloader.cs
+++ b/ModdingToolkitServerTestPlugin/Bootloader.cs
@@ -26,7 +26,16 @@ public class Bootloader : IAssemblyPlugin
         ce_float = ConfigManager.AddConfigEntry(
             "TestEntry00",
             "ModdingTK",
-            20.0f
+            20.0f,
+            validateNewInput: f =>
+            {
+                if (Utils.Game.IsRoundInProgress())
+                {
+                    Utils.Logging.PrintMessage($"Round in progress, cannot change value.");
+                    return false;
+                }
+                return true;
+            }
         );
         
         ce_int = ConfigManager.AddConfigEntry(

--- a/ReleaseChecklist.txt
+++ b/ReleaseChecklist.txt
@@ -1,0 +1,19 @@
+Todo on new version:
+
++++ Preparation - All:
+- Update Version numbers.
+- Compile Release and Debug Versions.
+- Create Changelog.
+
++++ Preparation - Steam Workshop:
+- Remove Server & Client testing plugins from /LocalMods.
+- Verify changes outside of /CSharp are copied (filelist.xml, RunConfig.xml)
+
++++ Post-Update - Steam Workshop:
+- Update description in Steam (Barotrauma bug).
+- Validate uploaded version received by Steam (Barotrauma bug).
+
++++ Preparation - Github
+- Update Readme.
+- Update Git Wiki.
+- Prepare Refs folder.

--- a/WindowsServer/WindowsServer.csproj
+++ b/WindowsServer/WindowsServer.csproj
@@ -81,6 +81,12 @@
       <Compile Include="..\ModdingToolkit\CSharp\Shared\Config\ConfigRangeInt.cs">
         <Link>Shared\Config\ConfigRangeInt.cs</Link>
       </Compile>
+      <Compile Include="..\ModdingToolkit\CSharp\Shared\Config\ECategory.cs">
+        <Link>Shared\Config\ECategory.cs</Link>
+      </Compile>
+      <Compile Include="..\ModdingToolkit\CSharp\Shared\Config\EDisplayType.cs">
+        <Link>Shared\Config\EDisplayType.cs</Link>
+      </Compile>
       <Compile Include="..\ModdingToolkit\CSharp\Shared\Config\IConfigBase.cs">
         <Link>Shared\Config\IConfigBase.cs</Link>
       </Compile>
@@ -95,6 +101,9 @@
       </Compile>
       <Compile Include="..\ModdingToolkit\CSharp\Shared\Config\IConfigRangeInt.cs">
         <Link>Shared\Config\IConfigRangeInt.cs</Link>
+      </Compile>
+      <Compile Include="..\ModdingToolkit\CSharp\Shared\Config\RDisplayData.cs">
+        <Link>Shared\Config\RDisplayData.cs</Link>
       </Compile>
       <Compile Include="..\ModdingToolkit\CSharp\Shared\ConsoleCommands.cs">
         <Link>Shared\ConsoleCommands.cs</Link>

--- a/WindowsServer/WindowsServer.csproj
+++ b/WindowsServer/WindowsServer.csproj
@@ -57,6 +57,9 @@
       <Compile Include="..\ModdingToolkit\CSharp\Server\Config\ConfigList.cs">
         <Link>Server\Config\ConfigList.cs</Link>
       </Compile>
+      <Compile Include="..\ModdingToolkit\CSharp\Server\Networking\NetVar.cs">
+        <Link>Server\Networking\NetVar.cs</Link>
+      </Compile>
       <Compile Include="..\ModdingToolkit\CSharp\Server\Networking\NetworkingManager.cs">
         <Link>Server\Networking\NetworkingManager.cs</Link>
       </Compile>
@@ -119,6 +122,12 @@
       </Compile>
       <Compile Include="..\ModdingToolkit\CSharp\Shared\Networking\INetConfigBase.cs">
         <Link>Shared\Networking\INetConfigBase.cs</Link>
+      </Compile>
+      <Compile Include="..\ModdingToolkit\CSharp\Shared\Networking\INetVar.cs">
+        <Link>Shared\Networking\INetVar.cs</Link>
+      </Compile>
+      <Compile Include="..\ModdingToolkit\CSharp\Shared\Networking\NetVar.cs">
+        <Link>Shared\Networking\NetVar.cs</Link>
       </Compile>
       <Compile Include="..\ModdingToolkit\CSharp\Shared\Networking\NetworkingManager.cs">
         <Link>Shared\Networking\NetworkingManager.cs</Link>

--- a/WindowsServer/WindowsServer.csproj
+++ b/WindowsServer/WindowsServer.csproj
@@ -114,6 +114,9 @@
       <Compile Include="..\ModdingToolkit\CSharp\Shared\global.cs">
         <Link>Shared\global.cs</Link>
       </Compile>
+      <Compile Include="..\ModdingToolkit\CSharp\Shared\MemoryCallbackCache.cs">
+        <Link>Shared\MemoryCallbackCache.cs</Link>
+      </Compile>
       <Compile Include="..\ModdingToolkit\CSharp\Shared\Networking\ENetworkEventId.cs">
         <Link>Shared\Networking\ENetworkEventId.cs</Link>
       </Compile>


### PR DESCRIPTION
Changelog:

- Reworked the SettingsMenu and display of CVars.
- Added `IDisplayable` interface for any GUI display of CVars.
- Added `INetVar<T>` and helper methods in `Utils.Networking` for Network SyncVars where file IO and display are not necessary.
- Added MemoryCallbackCache to aid in reverting old values.
- Clients with `ClientPermissions.ManageSettings` can now change server-side values marked with `ServerAuthority` (perms checked server-side).
- Bugfixes to Networking.